### PR TITLE
Remove nyhet label from utbetalinger menu

### DIFF
--- a/components/organisms/AdminPageHeader.vue
+++ b/components/organisms/AdminPageHeader.vue
@@ -150,7 +150,6 @@
                         </svg>
                       </span>
                       Utbetalinger
-                      <span class="coming-soon-label">NYHET</span>
                     </a>
                   </li>
                   <li>


### PR DESCRIPTION
Remove the 'NYHET' label from 'Utbetalinger' in the admin header menu.

---
[Slack Thread](https://okamtalk.slack.com/archives/C09HZ5QNT09/p1759093998808819?thread_ts=1759093998.808819&cid=C09HZ5QNT09)

<a href="https://cursor.com/background-agent?bcId=bc-a28c92e1-4d1a-46dd-8139-9d8589fbb2b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a28c92e1-4d1a-46dd-8139-9d8589fbb2b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

