### PR TITLE
Add Kunder, Bonus, Rabatter og Betaling admin pages to web

### DIFF
--- a/components/organisms/AdminPageHeader.vue
+++ b/components/organisms/AdminPageHeader.vue
@@ -346,6 +346,86 @@
                       Wolt
                     </a>
                   </li>
+                  <li>
+                    <a href="/admin/customers">
+                      <span class="menu-icon">
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                          />
+                        </svg>
+                      </span>
+                      Kunder
+                    </a>
+                  </li>
+                  <li>
+                    <a href="/admin/rewards">
+                      <span class="menu-icon">
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"
+                          />
+                        </svg>
+                      </span>
+                      Bonus
+                    </a>
+                  </li>
+                  <li>
+                    <a href="/admin/discounts">
+                      <span class="menu-icon">
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"
+                          />
+                        </svg>
+                      </span>
+                      Rabatter
+                    </a>
+                  </li>
+                  <li>
+                    <a href="/admin/payment">
+                      <span class="menu-icon">
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"
+                          />
+                        </svg>
+                      </span>
+                      Betaling
+                    </a>
+                  </li>
                   <li v-if="onboardingInProgress">
                     <a href="/admin/onboarding">
                       <span class="menu-icon">

--- a/pages/admin/customers.vue
+++ b/pages/admin/customers.vue
@@ -1,0 +1,874 @@
+<template>
+  <AdminPage @login-success="onLoginSuccess">
+    <div class="customers-page">
+      <div class="page-header">
+        <h1>Kunder</h1>
+        <p class="page-description">Søk etter kunder eller se statistikk og oversikt</p>
+      </div>
+
+      <!-- Search Bar -->
+      <div class="search-bar">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="search-icon">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0" />
+        </svg>
+        <input
+          v-model="searchQuery"
+          type="text"
+          placeholder="Søk på navn eller telefon (min. 3 tegn)..."
+          class="search-input"
+          @input="onSearchInput"
+        />
+        <button v-if="searchQuery" class="search-clear" @click="clearSearch">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <!-- Search Results -->
+      <template v-if="searchQuery.length > 0">
+        <div v-if="isSearching" class="loading-section">
+          <Loading :loading="true" />
+        </div>
+        <div v-else-if="searchQuery.length < 3" class="search-hint">
+          Skriv minst 3 tegn for å søke
+        </div>
+        <div v-else-if="customers.length === 0" class="empty-state">
+          <div class="empty-state__icon">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+          </div>
+          <h3>Ingen kunder funnet</h3>
+          <p>Ingen kunder matcher "{{ searchQuery }}"</p>
+        </div>
+        <div v-else class="customers-list">
+          <div
+            v-for="customer in customers"
+            :key="customer.userId || customer.phoneNumber"
+            class="customer-item"
+            @click="openCustomerModal(customer)"
+          >
+            <div class="customer-item__info">
+              <div class="customer-item__name" v-html="highlight(customer.fullName, searchQuery)" />
+              <div class="customer-item__phone" v-html="highlight(customer.phoneNumber, searchQuery)" />
+            </div>
+            <div class="customer-item__arrow">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <!-- Stats Dashboard (when no search) -->
+      <template v-else>
+        <div v-if="isLoadingStats" class="loading-section">
+          <Loading :loading="true" />
+        </div>
+
+        <template v-else-if="selectedStore">
+          <!-- Period Selector -->
+          <div class="period-selector">
+            <button
+              v-for="period in periodOptions"
+              :key="period.value"
+              class="period-btn"
+              :class="{ 'period-btn--active': selectedPeriod === period.value }"
+              @click="changePeriod(period.value)"
+            >
+              {{ period.label }}
+            </button>
+          </div>
+
+          <!-- Stats Cards -->
+          <div v-if="dashboardData.data && dashboardData.data.length" class="stats-grid">
+            <div v-for="stat in dashboardData.data" :key="stat.key" class="stat-card">
+              <div class="stat-card__value">{{ stat.value }}</div>
+              <div class="stat-card__label">{{ stat.key }}</div>
+            </div>
+          </div>
+
+          <!-- Platform Distribution -->
+          <div v-if="hasPlatformData" class="form-section">
+            <h2 class="section-title">Plattformfordeling</h2>
+            <div class="platform-chart">
+              <canvas ref="platformChart" width="200" height="200" class="pie-canvas" />
+              <div class="platform-legend">
+                <div class="legend-item">
+                  <span class="legend-dot" style="background: #1bb776;" />
+                  <span class="legend-label">iOS</span>
+                  <span class="legend-count">{{ dashboardData.iosCustomersCount || 0 }}</span>
+                </div>
+                <div class="legend-item">
+                  <span class="legend-dot" style="background: #6366f1;" />
+                  <span class="legend-label">Android</span>
+                  <span class="legend-count">{{ dashboardData.androidCustomersCount || 0 }}</span>
+                </div>
+                <div class="legend-item">
+                  <span class="legend-dot" style="background: #f59e0b;" />
+                  <span class="legend-label">Web</span>
+                  <span class="legend-count">{{ dashboardData.webCustomersCount || 0 }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Favorite Products -->
+          <div v-if="dashboardData.favoriteProducts && dashboardData.favoriteProducts.length" class="form-section">
+            <h2 class="section-title">Mest populære produkter</h2>
+            <div class="favorites-list">
+              <div
+                v-for="(product, index) in dashboardData.favoriteProducts"
+                :key="product.productId || index"
+                class="favorite-item"
+              >
+                <span class="favorite-rank">{{ index + 1 }}</span>
+                <span class="favorite-name">{{ product.productName }}</span>
+                <span class="favorite-count">{{ product.favoriteCount }} favoritter</span>
+              </div>
+            </div>
+          </div>
+        </template>
+
+        <div v-else class="empty-state">
+          <h3>Velg en butikk</h3>
+          <p>Velg en butikk for å se kundestatistikk.</p>
+        </div>
+      </template>
+
+      <!-- Customer Detail Modal -->
+      <div v-if="showCustomerModal" class="modal-overlay" @click.self="closeCustomerModal">
+        <div class="modal-container">
+          <div class="modal-header">
+            <h2>Kundeinformasjon</h2>
+            <button class="modal-close" @click="closeCustomerModal">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <div v-if="isLoadingCustomer" class="modal-loading">
+            <Loading :loading="true" />
+          </div>
+
+          <template v-else-if="customerDetail">
+            <div class="customer-info-list">
+              <div
+                v-for="(item, index) in customerDetail.data"
+                :key="index"
+                class="customer-info-row"
+              >
+                <span class="customer-info-row__key">{{ item.key }}</span>
+                <span class="customer-info-row__value">{{ item.value }}</span>
+              </div>
+            </div>
+
+            <div class="reward-section">
+              <h3 class="reward-section__title">Send bonuspoeng</h3>
+              <div class="reward-input-row">
+                <input
+                  v-model="rewardAmount"
+                  type="number"
+                  min="1"
+                  placeholder="Antall poeng"
+                  class="text-input"
+                />
+                <button
+                  class="btn btn-primary"
+                  :disabled="isSendingReward || !rewardAmount || Number(rewardAmount) <= 0"
+                  @click="sendReward"
+                >
+                  <span v-if="isSendingReward">Sender...</span>
+                  <span v-else>Send poeng</span>
+                </button>
+              </div>
+              <div v-if="rewardMessage" class="reward-message" :class="`reward-message--${rewardMessageType}`">
+                {{ rewardMessage }}
+              </div>
+            </div>
+          </template>
+        </div>
+      </div>
+    </div>
+  </AdminPage>
+</template>
+
+<script>
+import AdminPage from '~/components/organisms/AdminPage.vue'
+import Loading from '~/components/atoms/Loading.vue'
+import { debounce } from '~/core/helpers/ts-debounce'
+
+export default {
+  name: 'Customers',
+  components: { AdminPage, Loading },
+  data() {
+    return {
+      searchQuery: '',
+      isSearching: false,
+      isLoadingStats: false,
+      customers: [],
+      selectedPeriod: 30,
+      dashboardData: {
+        data: [],
+        iosCustomersCount: 0,
+        androidCustomersCount: 0,
+        webCustomersCount: 0,
+        favoriteProducts: [],
+      },
+      showCustomerModal: false,
+      selectedCustomer: null,
+      customerDetail: null,
+      isLoadingCustomer: false,
+      rewardAmount: '',
+      isSendingReward: false,
+      rewardMessage: '',
+      rewardMessageType: 'success',
+      pieChartInstance: null,
+      debouncedSearch: null,
+    }
+  },
+  computed: {
+    selectedStore() {
+      return this.$store.state.selectedAdminStore
+    },
+    periodOptions() {
+      return [
+        { label: '1 dag', value: 1 },
+        { label: '7 dager', value: 7 },
+        { label: '30 dager', value: 30 },
+        { label: '45 dager', value: 45 },
+        { label: '90 dager', value: 90 },
+        { label: 'Dette året', value: 365 },
+        { label: 'Siden start', value: 9999 },
+      ]
+    },
+    hasPlatformData() {
+      return (
+        (this.dashboardData.iosCustomersCount || 0) +
+        (this.dashboardData.androidCustomersCount || 0) +
+        (this.dashboardData.webCustomersCount || 0) > 0
+      )
+    },
+  },
+  watch: {
+    selectedStore: {
+      immediate: true,
+      handler(storeId) {
+        if (storeId && !this.searchQuery) this.loadStats(storeId)
+      },
+    },
+    hasPlatformData(val) {
+      if (val) this.$nextTick(() => this.renderPieChart())
+    },
+  },
+  created() {
+    this.debouncedSearch = debounce(this.searchCustomers, 500)
+  },
+  beforeDestroy() {
+    if (this.pieChartInstance) {
+      this.pieChartInstance.destroy()
+      this.pieChartInstance = null
+    }
+  },
+  methods: {
+    onLoginSuccess() {
+      if (this.selectedStore && !this.searchQuery) this.loadStats(this.selectedStore)
+    },
+    async loadStats(storeId) {
+      this.isLoadingStats = true
+      try {
+        const result = await this._storeService.GetCustomerStatistics(storeId || this.selectedStore, this.selectedPeriod)
+        this.dashboardData = result || {}
+        if (this.hasPlatformData) {
+          this.$nextTick(() => this.renderPieChart())
+        }
+      } catch (e) {
+        this.dashboardData = { data: [], iosCustomersCount: 0, androidCustomersCount: 0, webCustomersCount: 0, favoriteProducts: [] }
+      } finally {
+        this.isLoadingStats = false
+      }
+    },
+    changePeriod(period) {
+      this.selectedPeriod = period
+      if (this.selectedStore) this.loadStats(this.selectedStore)
+    },
+    onSearchInput() {
+      if (this.searchQuery.length === 0) {
+        this.customers = []
+        if (this.selectedStore) this.loadStats(this.selectedStore)
+        return
+      }
+      if (this.searchQuery.length >= 3) {
+        this.debouncedSearch()
+      }
+    },
+    clearSearch() {
+      this.searchQuery = ''
+      this.customers = []
+      if (this.selectedStore) this.loadStats(this.selectedStore)
+    },
+    async searchCustomers() {
+      if (!this.selectedStore || this.searchQuery.length < 3) return
+      this.isSearching = true
+      try {
+        this.customers = await this._storeService.SearchCustomers(this.selectedStore, this.searchQuery) || []
+      } catch (e) {
+        this.customers = []
+      } finally {
+        this.isSearching = false
+      }
+    },
+    async openCustomerModal(customer) {
+      this.selectedCustomer = customer
+      this.showCustomerModal = true
+      this.customerDetail = null
+      this.rewardAmount = ''
+      this.rewardMessage = ''
+      this.isLoadingCustomer = true
+      try {
+        this.customerDetail = await this._userService.GetForStore(this.selectedStore, customer.userId)
+      } catch (e) {
+        this.customerDetail = null
+      } finally {
+        this.isLoadingCustomer = false
+      }
+    },
+    closeCustomerModal() {
+      this.showCustomerModal = false
+      this.selectedCustomer = null
+      this.customerDetail = null
+    },
+    async sendReward() {
+      if (!this.rewardAmount || Number(this.rewardAmount) <= 0) return
+      this.isSendingReward = true
+      this.rewardMessage = ''
+      try {
+        await this._rewardService.SendReward(this.selectedStore, this.selectedCustomer.userId, Number(this.rewardAmount) * 100)
+        this.rewardMessage = `${this.rewardAmount} bonuspoeng sendt!`
+        this.rewardMessageType = 'success'
+        this.rewardAmount = ''
+      } catch (e) {
+        this.rewardMessage = 'Kunne ikke sende bonuspoeng. Prøv igjen.'
+        this.rewardMessageType = 'error'
+      } finally {
+        this.isSendingReward = false
+      }
+    },
+    highlight(text, query) {
+      if (!text || !query) return text || ''
+      const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      return text.replace(new RegExp(`(${escaped})`, 'gi'), '<mark>$1</mark>')
+    },
+    renderPieChart() {
+      const canvas = this.$refs.platformChart
+      if (!canvas) return
+
+      if (this.pieChartInstance) {
+        this.pieChartInstance.destroy()
+        this.pieChartInstance = null
+      }
+
+      const ios = this.dashboardData.iosCustomersCount || 0
+      const android = this.dashboardData.androidCustomersCount || 0
+      const web = this.dashboardData.webCustomersCount || 0
+
+      if (ios + android + web === 0) return
+
+      import('chart.js').then(({ Chart, ArcElement, PieController, Tooltip, Legend }) => {
+        Chart.register(ArcElement, PieController, Tooltip, Legend)
+        this.pieChartInstance = new Chart(canvas, {
+          type: 'pie',
+          data: {
+            labels: ['iOS', 'Android', 'Web'],
+            datasets: [{
+              data: [ios, android, web],
+              backgroundColor: ['#1bb776', '#6366f1', '#f59e0b'],
+              borderWidth: 0,
+            }],
+          },
+          options: {
+            responsive: false,
+            plugins: {
+              legend: { display: false },
+              tooltip: { enabled: true },
+            },
+          },
+        })
+      })
+    },
+  },
+}
+</script>
+
+<style scoped>
+.customers-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.page-header {
+  margin-bottom: 24px;
+}
+
+.page-header h1 {
+  font-size: 28px;
+  font-weight: 700;
+  color: #292c34;
+  margin: 0 0 4px;
+}
+
+.page-description {
+  color: #6b7280;
+  margin: 0;
+  font-size: 14px;
+}
+
+.search-bar {
+  position: relative;
+  margin-bottom: 24px;
+}
+
+.search-icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 18px;
+  color: #9ca3af;
+}
+
+.search-input {
+  width: 100%;
+  padding: 12px 40px;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  font-size: 14px;
+  color: #292c34;
+  background: white;
+  box-sizing: border-box;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #1bb776;
+  box-shadow: 0 0 0 3px rgba(27, 183, 118, 0.12);
+}
+
+.search-clear {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  background: #f3f4f6;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  color: #6b7280;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.search-clear:hover { background: #e5e7eb; }
+.search-clear svg { width: 14px; height: 14px; }
+
+.search-hint {
+  text-align: center;
+  color: #9ca3af;
+  font-size: 14px;
+  padding: 32px;
+}
+
+.loading-section {
+  display: flex;
+  justify-content: center;
+  padding: 60px 0;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 60px 24px;
+  color: #6b7280;
+}
+
+.empty-state__icon {
+  width: 56px;
+  height: 56px;
+  margin: 0 auto 16px;
+  color: #d1d5db;
+}
+
+.empty-state__icon svg { width: 100%; height: 100%; }
+
+.empty-state h3 {
+  font-size: 18px;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 8px;
+}
+
+.empty-state p { font-size: 14px; margin: 0; }
+
+.customers-list {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+}
+
+.customer-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid #f3f4f6;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.customer-item:last-child { border-bottom: none; }
+.customer-item:hover { background: #f9fafb; }
+
+.customer-item__info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.customer-item__name {
+  font-size: 15px;
+  font-weight: 600;
+  color: #292c34;
+}
+
+.customer-item__phone {
+  font-size: 13px;
+  color: #6b7280;
+}
+
+.customer-item__arrow {
+  width: 20px;
+  height: 20px;
+  color: #d1d5db;
+}
+
+.customer-item__arrow svg { width: 100%; height: 100%; }
+
+.period-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.period-btn {
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid #e5e7eb;
+  background: white;
+  font-size: 13px;
+  font-weight: 500;
+  color: #6b7280;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.period-btn:hover { border-color: #1bb776; color: #1bb776; }
+.period-btn--active { background: #1bb776; color: white; border-color: #1bb776; }
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.stat-card {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  padding: 20px;
+  text-align: center;
+}
+
+.stat-card__value {
+  font-size: 28px;
+  font-weight: 700;
+  color: #1bb776;
+}
+
+.stat-card__label {
+  font-size: 12px;
+  color: #9ca3af;
+  margin-top: 4px;
+}
+
+.form-section {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  padding: 24px;
+  margin-bottom: 20px;
+}
+
+.section-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #292c34;
+  margin: 0 0 20px;
+}
+
+.platform-chart {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  flex-wrap: wrap;
+}
+
+.pie-canvas { max-width: 160px; }
+
+.platform-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.legend-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.legend-label {
+  font-size: 14px;
+  color: #374151;
+  flex: 1;
+}
+
+.legend-count {
+  font-size: 14px;
+  font-weight: 700;
+  color: #292c34;
+}
+
+.favorites-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.favorite-item {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 0;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.favorite-item:last-child { border-bottom: none; }
+
+.favorite-rank {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: #f0fdf4;
+  color: #1bb776;
+  font-size: 13px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.favorite-name {
+  flex: 1;
+  font-size: 14px;
+  color: #374151;
+  font-weight: 500;
+}
+
+.favorite-count {
+  font-size: 13px;
+  color: #9ca3af;
+}
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 24px;
+}
+
+.modal-container {
+  background: white;
+  border-radius: 16px;
+  width: 100%;
+  max-width: 500px;
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px;
+  border-bottom: 1px solid #f3f4f6;
+  position: sticky;
+  top: 0;
+  background: white;
+}
+
+.modal-header h2 {
+  font-size: 18px;
+  font-weight: 700;
+  color: #292c34;
+  margin: 0;
+}
+
+.modal-close {
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: #f3f4f6;
+  border-radius: 50%;
+  cursor: pointer;
+  color: #6b7280;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-close:hover { background: #e5e7eb; }
+.modal-close svg { width: 16px; height: 16px; }
+
+.modal-loading {
+  display: flex;
+  justify-content: center;
+  padding: 40px;
+}
+
+.customer-info-list {
+  padding: 0 24px;
+}
+
+.customer-info-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 0;
+  border-bottom: 1px solid #f3f4f6;
+  gap: 16px;
+}
+
+.customer-info-row:last-child { border-bottom: none; }
+
+.customer-info-row__key {
+  font-size: 13px;
+  color: #9ca3af;
+  flex-shrink: 0;
+}
+
+.customer-info-row__value {
+  font-size: 14px;
+  font-weight: 500;
+  color: #292c34;
+  text-align: right;
+}
+
+.reward-section {
+  padding: 20px 24px;
+  border-top: 1px solid #f3f4f6;
+  background: #f9fafb;
+}
+
+.reward-section__title {
+  font-size: 15px;
+  font-weight: 700;
+  color: #292c34;
+  margin: 0 0 12px;
+}
+
+.reward-input-row {
+  display: flex;
+  gap: 12px;
+}
+
+.text-input {
+  flex: 1;
+  padding: 10px 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 14px;
+  color: #292c34;
+  background: white;
+  box-sizing: border-box;
+}
+
+.text-input:focus {
+  outline: none;
+  border-color: #1bb776;
+}
+
+.reward-message {
+  margin-top: 10px;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 8px 12px;
+  border-radius: 6px;
+}
+
+.reward-message--success { background: #d1fae5; color: #065f46; }
+.reward-message--error { background: #fee2e2; color: #dc2626; }
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: opacity 0.2s;
+  white-space: nowrap;
+}
+
+.btn:hover { opacity: 0.85; }
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn-primary { background: linear-gradient(135deg, #1bb776, #159f63); color: white; }
+</style>
+
+<style>
+.customer-item__name mark,
+.customer-item__phone mark {
+  background: #fef08a;
+  color: inherit;
+  border-radius: 2px;
+  padding: 0 1px;
+}
+</style>

--- a/pages/admin/discount.vue
+++ b/pages/admin/discount.vue
@@ -1,0 +1,773 @@
+<template>
+  <AdminPage @login-success="loadData">
+    <div class="discount-page">
+      <div class="page-header">
+        <a href="/admin/discounts" class="back-link">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+          </svg>
+          Rabatter
+        </a>
+        <h1>{{ isNew ? 'Ny rabatt' : 'Rediger rabatt' }}</h1>
+      </div>
+
+      <div v-if="isLoading" class="loading-section">
+        <Loading :loading="true" />
+      </div>
+
+      <template v-else-if="localDiscount">
+        <div v-if="errors.length" class="error-banner">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+          <ul>
+            <li v-for="(err, i) in errors" :key="i">{{ err }}</li>
+          </ul>
+        </div>
+
+        <!-- Label -->
+        <div class="form-section">
+          <h2 class="section-title">Navn</h2>
+          <div class="form-field" :class="{ 'form-field--error': fieldErrors.label }">
+            <label>Navn på rabatt</label>
+            <input
+              v-model="localDiscount.label"
+              type="text"
+              maxlength="25"
+              placeholder="F.eks. Sommerrabatt"
+              class="text-input"
+            />
+            <span class="field-hint">{{ (localDiscount.label || '').length }}/25 tegn</span>
+          </div>
+        </div>
+
+        <!-- Amount & Type -->
+        <div class="form-section">
+          <h2 class="section-title">Rabattverdi</h2>
+          <div class="amount-row">
+            <div class="form-field" :class="{ 'form-field--error': fieldErrors.discount }">
+              <label>Beløp</label>
+              <input
+                v-model="localDiscount.discount"
+                type="number"
+                min="0"
+                placeholder="0"
+                class="text-input"
+              />
+            </div>
+            <div class="type-toggle">
+              <button
+                class="type-btn"
+                :class="{ 'type-btn--active': localDiscount.type === 'Amount' }"
+                @click="localDiscount.type = 'Amount'"
+              >
+                kr
+              </button>
+              <button
+                class="type-btn"
+                :class="{ 'type-btn--active': localDiscount.type === 'Percent' }"
+                @click="localDiscount.type = 'Percent'"
+              >
+                %
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Applicability -->
+        <div class="form-section">
+          <h2 class="section-title">Gjelder for</h2>
+          <div class="form-field">
+            <label>Bruksområde</label>
+            <select v-model="localDiscount.applicability" class="select-input">
+              <option value="Order">Hele ordren</option>
+              <option value="HomeDelivery">Kun hjemlevering</option>
+              <option value="SelfPickup">Kun henting</option>
+              <option value="DineIn">Kun spis inne</option>
+              <option value="ProductsInclusive">Bestemte produkter (inklusiv)</option>
+              <option value="ProductsExclusive">Bestemte produkter (eksklusiv)</option>
+            </select>
+          </div>
+          <div
+            v-if="localDiscount.applicability === 'ProductsInclusive' || localDiscount.applicability === 'ProductsExclusive'"
+            class="product-selector-row"
+          >
+            <button class="btn btn-secondary" @click="openProductPicker">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="btn-icon">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+              </svg>
+              Velg produkter
+            </button>
+            <span class="product-count-label">
+              {{ selectedProductIds.length }} produkt{{ selectedProductIds.length !== 1 ? 'er' : '' }} valgt
+            </span>
+          </div>
+        </div>
+
+        <!-- Code -->
+        <div class="form-section">
+          <h2 class="section-title">Kampanjekode (valgfritt)</h2>
+          <div class="form-field">
+            <label>Kode</label>
+            <input
+              v-model="localDiscount.code"
+              type="text"
+              maxlength="20"
+              placeholder="F.eks. SOMMER20"
+              class="text-input text-input--mono"
+            />
+            <span class="field-hint">Legg til en kode kunder må oppgi for å bruke rabatten</span>
+          </div>
+        </div>
+
+        <!-- Conditions -->
+        <div class="form-section">
+          <h2 class="section-title">Betingelser</h2>
+
+          <div class="condition-row">
+            <div class="condition-toggle-row">
+              <label class="toggle-label">Minimum ordreverdi</label>
+              <label class="toggle-switch">
+                <input v-model="localDiscount.minimumOrderAmountEnabled" type="checkbox" />
+                <span class="toggle-slider" />
+              </label>
+            </div>
+            <div v-if="localDiscount.minimumOrderAmountEnabled" class="condition-input">
+              <input
+                v-model="localDiscount.minimumOrderAmount"
+                type="number"
+                min="0"
+                placeholder="0"
+                class="text-input"
+              />
+              <span class="input-suffix">kr</span>
+            </div>
+          </div>
+
+          <div class="condition-row">
+            <div class="condition-toggle-row">
+              <label class="toggle-label">Maks antall ganger brukt totalt</label>
+              <label class="toggle-switch">
+                <input v-model="localDiscount.maximumTotalUsageCountEnabled" type="checkbox" />
+                <span class="toggle-slider" />
+              </label>
+            </div>
+            <div v-if="localDiscount.maximumTotalUsageCountEnabled" class="condition-input">
+              <input
+                v-model="localDiscount.maximumTotalUsageCount"
+                type="number"
+                min="1"
+                placeholder="10"
+                class="text-input"
+              />
+              <span class="input-suffix">ganger</span>
+            </div>
+          </div>
+
+          <div class="condition-row">
+            <div class="condition-toggle-row">
+              <label class="toggle-label">Maks bruk per kunde</label>
+              <label class="toggle-switch">
+                <input v-model="localDiscount.maximumUsagePerCustomerCountEnabled" type="checkbox" />
+                <span class="toggle-slider" />
+              </label>
+            </div>
+            <div v-if="localDiscount.maximumUsagePerCustomerCountEnabled" class="condition-input">
+              <input
+                v-model="localDiscount.maximumUsagePerCustomerCount"
+                type="number"
+                min="1"
+                placeholder="1"
+                class="text-input"
+              />
+              <span class="input-suffix">ganger</span>
+            </div>
+          </div>
+
+          <div class="condition-row">
+            <div class="condition-toggle-row">
+              <label class="toggle-label">Tidsbegrenset</label>
+              <label class="toggle-switch">
+                <input v-model="localDiscount.timedEnabled" type="checkbox" />
+                <span class="toggle-slider" />
+              </label>
+            </div>
+            <div v-if="localDiscount.timedEnabled" class="datetime-inputs">
+              <div class="form-field">
+                <label>Gyldig fra</label>
+                <input v-model="localDiscount.validFrom" type="datetime-local" class="text-input" />
+              </div>
+              <div class="form-field">
+                <label>Gyldig til</label>
+                <input v-model="localDiscount.validTo" type="datetime-local" class="text-input" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Special Options -->
+        <div class="form-section">
+          <h2 class="section-title">Spesielle innstillinger</h2>
+
+          <div class="condition-toggle-row">
+            <label class="toggle-label">
+              <span>Gi bonuspoeng i stedet for rabatt</span>
+              <span class="toggle-hint">Kunden mottar poeng fremfor prisreduksjon</span>
+            </label>
+            <label class="toggle-switch">
+              <input v-model="localDiscount.giveRewardInsteadOfDiscountEnabled" type="checkbox" />
+              <span class="toggle-slider" />
+            </label>
+          </div>
+
+          <div v-if="!isNew" class="condition-toggle-row" style="margin-top: 16px;">
+            <label class="toggle-label">
+              <span>Marker som utløpt</span>
+              <span class="toggle-hint">Rabatten vil ikke lenger kunne brukes</span>
+            </label>
+            <label class="toggle-switch">
+              <input v-model="localDiscount.expired" type="checkbox" />
+              <span class="toggle-slider" />
+            </label>
+          </div>
+        </div>
+
+        <!-- Usage Stats -->
+        <div v-if="!isNew && localDiscount.discountUsages" class="form-section">
+          <h2 class="section-title">Statistikk</h2>
+          <div class="stats-row">
+            <span class="stats-label">Ganger brukt:</span>
+            <span class="stats-value">{{ localDiscount.discountUsages.length }}</span>
+          </div>
+        </div>
+
+        <!-- Actions -->
+        <div class="action-bar">
+          <div class="action-bar__left">
+            <button v-if="!isNew" class="btn btn-danger" :disabled="isSaving" @click="confirmDelete">
+              Slett rabatt
+            </button>
+          </div>
+          <div class="action-bar__right">
+            <a href="/admin/discounts" class="btn btn-ghost">Avbryt</a>
+            <button class="btn btn-primary" :disabled="isSaving" @click="saveDiscount">
+              <span v-if="isSaving">Lagrer...</span>
+              <span v-else>{{ isNew ? 'Opprett rabatt' : 'Lagre endringer' }}</span>
+            </button>
+          </div>
+        </div>
+      </template>
+
+      <!-- Product Selector Modal -->
+      <ProductSelectorModal ref="productSelector" />
+
+      <!-- Toast -->
+      <transition name="toast">
+        <div v-if="toast.show" class="toast" :class="`toast--${toast.type}`">
+          {{ toast.message }}
+        </div>
+      </transition>
+    </div>
+  </AdminPage>
+</template>
+
+<script>
+import AdminPage from '~/components/organisms/AdminPage.vue'
+import Loading from '~/components/atoms/Loading.vue'
+import ProductSelectorModal from '~/components/admin/ProductSelectorModal.vue'
+
+export default {
+  name: 'Discount',
+  components: { AdminPage, Loading, ProductSelectorModal },
+  data() {
+    return {
+      isLoading: false,
+      isSaving: false,
+      localDiscount: null,
+      selectedProductIds: [],
+      errors: [],
+      fieldErrors: {},
+      toast: { show: false, message: '', type: 'success' },
+    }
+  },
+  computed: {
+    selectedStore() {
+      return this.$store.state.selectedAdminStore
+    },
+    discountId() {
+      return this.$route.query.id
+    },
+    isNew() {
+      return this.discountId === 'new'
+    },
+  },
+  watch: {
+    selectedStore(storeId) {
+      if (storeId && !this.isNew) {
+        this.$router.push('/admin/discounts')
+      }
+    },
+  },
+  async mounted() {
+    await this.loadData()
+  },
+  methods: {
+    async loadData() {
+      const storeId = this.selectedStore
+      if (!storeId) return
+
+      if (this.isNew) {
+        this.localDiscount = {
+          storeId,
+          label: '',
+          discount: '',
+          type: 'Amount',
+          applicability: 'Order',
+          code: '',
+          minimumOrderAmount: 0,
+          minimumOrderAmountEnabled: false,
+          maximumTotalUsageCount: 0,
+          maximumTotalUsageCountEnabled: false,
+          maximumUsagePerCustomerCount: 0,
+          maximumUsagePerCustomerCountEnabled: false,
+          timedEnabled: false,
+          validFrom: null,
+          validTo: null,
+          giveRewardInsteadOfDiscountEnabled: false,
+          expired: false,
+          discountProducts: [],
+          discountUsages: [],
+        }
+        return
+      }
+
+      this.isLoading = true
+      try {
+        const discounts = await this._discountService.Get(storeId)
+        const found = discounts.find(d => d.id === this.discountId)
+        if (!found) {
+          this.$router.push('/admin/discounts')
+          return
+        }
+        this.localDiscount = { ...found }
+        this.selectedProductIds = (found.discountProducts || []).map(p => p.productId)
+      } catch (e) {
+        this.$router.push('/admin/discounts')
+      } finally {
+        this.isLoading = false
+      }
+    },
+    async openProductPicker() {
+      const picked = await this.$refs.productSelector.open(this.selectedProductIds)
+      if (picked !== undefined) {
+        this.selectedProductIds = picked
+        this.localDiscount.discountProducts = picked.map(id => ({ productId: id }))
+      }
+    },
+    validate() {
+      this.errors = []
+      this.fieldErrors = {}
+
+      if (!this.localDiscount.label || this.localDiscount.label.trim().length < 3) {
+        this.errors.push('Navn på rabatt må være minst 3 tegn')
+        this.fieldErrors.label = true
+      }
+      if (!this.localDiscount.discount || Number(this.localDiscount.discount) <= 0) {
+        this.errors.push('Rabattbeløp må være større enn 0')
+        this.fieldErrors.discount = true
+      }
+      if (this.localDiscount.type === 'Percent' && Number(this.localDiscount.discount) > 100) {
+        this.errors.push('Prosent kan ikke være mer enn 100')
+        this.fieldErrors.discount = true
+      }
+
+      return this.errors.length === 0
+    },
+    async saveDiscount() {
+      if (!this.validate()) return
+
+      this.isSaving = true
+      try {
+        const payload = {
+          ...this.localDiscount,
+          storeId: this.selectedStore,
+          discount: String(this.localDiscount.discount),
+        }
+        await this._discountService.CreateOrUpdate(payload)
+        this.showToast('Rabatt lagret', 'success')
+        setTimeout(() => this.$router.push('/admin/discounts'), 1000)
+      } catch (e) {
+        this.showToast('Noe gikk galt. Prøv igjen.', 'error')
+      } finally {
+        this.isSaving = false
+      }
+    },
+    async confirmDelete() {
+      if (!confirm(`Er du sikker på at du vil slette rabatten "${this.localDiscount.label}"?`)) return
+
+      this.isSaving = true
+      try {
+        await this._discountService.Delete(this.localDiscount.id)
+        this.$router.push('/admin/discounts')
+      } catch (e) {
+        this.showToast('Kunne ikke slette rabatt. Prøv igjen.', 'error')
+        this.isSaving = false
+      }
+    },
+    showToast(message, type = 'success') {
+      this.toast = { show: true, message, type }
+      setTimeout(() => { this.toast.show = false }, 3000)
+    },
+  },
+}
+</script>
+
+<style scoped>
+.discount-page {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: #6b7280;
+  font-size: 14px;
+  text-decoration: none;
+  margin-bottom: 8px;
+}
+
+.back-link:hover { color: #292c34; }
+.back-link svg { width: 16px; height: 16px; }
+
+.page-header h1 {
+  font-size: 28px;
+  font-weight: 700;
+  color: #292c34;
+  margin: 0 0 24px;
+}
+
+.loading-section {
+  display: flex;
+  justify-content: center;
+  padding: 60px 0;
+}
+
+.error-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  background: #fee2e2;
+  border: 1px solid #fca5a5;
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 24px;
+  color: #dc2626;
+}
+
+.error-banner svg {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.error-banner ul {
+  margin: 0;
+  padding: 0 0 0 16px;
+  font-size: 14px;
+}
+
+.form-section {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  padding: 24px;
+  margin-bottom: 20px;
+}
+
+.section-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #292c34;
+  margin: 0 0 16px;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.form-field:last-child { margin-bottom: 0; }
+
+.form-field label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.form-field--error .text-input {
+  border-color: #dc2626;
+}
+
+.text-input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 14px;
+  color: #292c34;
+  background: #fafafa;
+  transition: border-color 0.2s;
+  box-sizing: border-box;
+}
+
+.text-input:focus {
+  outline: none;
+  border-color: #1bb776;
+  background: white;
+}
+
+.text-input--mono { font-family: monospace; }
+
+.select-input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 14px;
+  color: #292c34;
+  background: #fafafa;
+  cursor: pointer;
+}
+
+.select-input:focus {
+  outline: none;
+  border-color: #1bb776;
+}
+
+.field-hint {
+  font-size: 12px;
+  color: #9ca3af;
+}
+
+.amount-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.amount-row .form-field { flex: 1; margin-bottom: 0; }
+
+.type-toggle {
+  display: flex;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+  margin-bottom: 0;
+  flex-shrink: 0;
+}
+
+.type-btn {
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  border: none;
+  background: #f3f4f6;
+  color: #6b7280;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.type-btn--active {
+  background: #1bb776;
+  color: white;
+}
+
+.product-selector-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.product-count-label {
+  font-size: 13px;
+  color: #6b7280;
+}
+
+.condition-row {
+  padding: 16px 0;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.condition-row:last-child { border-bottom: none; }
+
+.condition-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.toggle-label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #292c34;
+  cursor: pointer;
+  flex: 1;
+}
+
+.toggle-hint {
+  font-size: 12px;
+  font-weight: 400;
+  color: #9ca3af;
+}
+
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.toggle-switch input { opacity: 0; width: 0; height: 0; }
+
+.toggle-slider {
+  position: absolute;
+  inset: 0;
+  background: #e5e7eb;
+  border-radius: 24px;
+  transition: background 0.2s;
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  left: 3px;
+  top: 3px;
+  background: white;
+  border-radius: 50%;
+  transition: transform 0.2s;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+}
+
+.toggle-switch input:checked + .toggle-slider { background: #1bb776; }
+.toggle-switch input:checked + .toggle-slider::before { transform: translateX(20px); }
+
+.condition-input {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.condition-input .text-input { max-width: 160px; }
+
+.input-suffix {
+  font-size: 14px;
+  color: #6b7280;
+  white-space: nowrap;
+}
+
+.datetime-inputs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 12px;
+}
+
+.stats-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.stats-label {
+  font-size: 14px;
+  color: #6b7280;
+}
+
+.stats-value {
+  font-size: 20px;
+  font-weight: 700;
+  color: #292c34;
+}
+
+.action-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 24px 0;
+  flex-wrap: wrap;
+}
+
+.action-bar__right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: opacity 0.2s;
+  text-decoration: none;
+}
+
+.btn:hover { opacity: 0.85; }
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.btn-primary { background: linear-gradient(135deg, #1bb776, #159f63); color: white; }
+.btn-secondary { background: #f3f4f6; color: #374151; border: 1px solid #e5e7eb; }
+.btn-ghost { background: transparent; color: #6b7280; }
+.btn-ghost:hover { background: #f3f4f6; }
+.btn-danger { background: transparent; color: #dc2626; border: 1px solid #fca5a5; }
+.btn-danger:hover { background: #fee2e2; }
+
+.btn-icon { width: 16px; height: 16px; }
+
+.toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  padding: 14px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  z-index: 1000;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+}
+
+.toast--success { background: #1bb776; color: white; }
+.toast--error { background: #dc2626; color: white; }
+
+.toast-enter-active, .toast-leave-active { transition: all 0.3s; }
+.toast-enter, .toast-leave-to { opacity: 0; transform: translateY(12px); }
+
+@media (max-width: 640px) {
+  .discount-page { padding: 16px; }
+  .datetime-inputs { grid-template-columns: 1fr; }
+  .action-bar { flex-direction: column; align-items: stretch; }
+  .action-bar__right { justify-content: flex-end; }
+}
+</style>

--- a/pages/admin/discounts.vue
+++ b/pages/admin/discounts.vue
@@ -1,0 +1,310 @@
+<template>
+  <AdminPage @login-success="loadDiscounts">
+    <div class="discounts-page">
+      <div class="page-header">
+        <div class="page-header__left">
+          <h1>Rabatter</h1>
+          <p class="page-description">Opprett og administrer rabatter og kampanjekoder</p>
+        </div>
+        <button class="btn btn-primary" @click="createDiscount">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="btn-icon">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+          </svg>
+          Opprett rabatt
+        </button>
+      </div>
+
+      <div v-if="isLoading" class="loading-section">
+        <Loading :loading="true" />
+      </div>
+
+      <div v-else-if="!selectedStore" class="empty-state">
+        <div class="empty-state__icon">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+          </svg>
+        </div>
+        <h3>Velg en butikk</h3>
+        <p>Velg en butikk for å se og administrere rabatter.</p>
+      </div>
+
+      <div v-else-if="discounts.length === 0" class="empty-state">
+        <div class="empty-state__icon">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+          </svg>
+        </div>
+        <h3>Ingen rabatter</h3>
+        <p>Det finnes ingen rabatter for denne butikken ennå.</p>
+        <button class="btn btn-primary" @click="createDiscount">Opprett første rabatt</button>
+      </div>
+
+      <div v-else class="discounts-list">
+        <div
+          v-for="discount in discounts"
+          :key="discount.id"
+          class="discount-item"
+          :class="{ 'discount-item--expired': discount.expired || discount.isUnavailable }"
+          @click="editDiscount(discount)"
+        >
+          <div class="discount-item__main">
+            <div class="discount-item__info">
+              <span class="discount-item__label" :class="{ 'discount-item__label--expired': discount.expired }">
+                {{ discount.label }}
+              </span>
+              <span v-if="discount.code" class="discount-item__code">{{ discount.code }}</span>
+            </div>
+            <div class="discount-item__meta">
+              <span v-if="discount.expired" class="badge badge--expired">Utløpt</span>
+              <span v-else-if="discount.isUnavailable" class="badge badge--unavailable">Utilgjengelig</span>
+            </div>
+          </div>
+          <div class="discount-item__amount">
+            <span :class="{ 'text-strikethrough': discount.expired }">
+              {{ formatDiscountAmount(discount) }}
+            </span>
+          </div>
+          <div class="discount-item__arrow">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </AdminPage>
+</template>
+
+<script>
+import AdminPage from '~/components/organisms/AdminPage.vue'
+import Loading from '~/components/atoms/Loading.vue'
+
+export default {
+  name: 'Discounts',
+  components: { AdminPage, Loading },
+  data() {
+    return {
+      isLoading: false,
+      discounts: [],
+    }
+  },
+  computed: {
+    selectedStore() {
+      return this.$store.state.selectedAdminStore
+    },
+  },
+  watch: {
+    selectedStore: {
+      immediate: true,
+      handler(storeId) {
+        if (storeId) this.loadDiscounts(storeId)
+      },
+    },
+  },
+  methods: {
+    async loadDiscounts(storeId) {
+      this.isLoading = true
+      try {
+        this.discounts = await this._discountService.Get(storeId || this.selectedStore)
+      } catch (e) {
+        this.discounts = []
+      } finally {
+        this.isLoading = false
+      }
+    },
+    createDiscount() {
+      this.$router.push('/admin/discount?id=new')
+    },
+    editDiscount(discount) {
+      this.$router.push(`/admin/discount?id=${discount.id}`)
+    },
+    formatDiscountAmount(discount) {
+      if (discount.type === 'Percent') {
+        return `${discount.discount}%`
+      }
+      return `${discount.discount} kr`
+    },
+  },
+}
+</script>
+
+<style scoped>
+.discounts-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 32px;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.page-header h1 {
+  font-size: 28px;
+  font-weight: 700;
+  color: #292c34;
+  margin: 0 0 4px;
+}
+
+.page-description {
+  color: #6b7280;
+  margin: 0;
+  font-size: 14px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: opacity 0.2s;
+  white-space: nowrap;
+}
+
+.btn:hover { opacity: 0.9; }
+
+.btn-primary {
+  background: linear-gradient(135deg, #1bb776, #159f63);
+  color: white;
+}
+
+.btn-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.loading-section {
+  display: flex;
+  justify-content: center;
+  padding: 60px 0;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 60px 24px;
+  color: #6b7280;
+}
+
+.empty-state__icon {
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 16px;
+  color: #d1d5db;
+}
+
+.empty-state__icon svg { width: 100%; height: 100%; }
+
+.empty-state h3 {
+  font-size: 18px;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 8px;
+}
+
+.empty-state p {
+  margin: 0 0 24px;
+  font-size: 14px;
+}
+
+.discounts-list {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+}
+
+.discount-item {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  cursor: pointer;
+  border-bottom: 1px solid #f3f4f6;
+  transition: background 0.15s;
+}
+
+.discount-item:last-child { border-bottom: none; }
+.discount-item:hover { background: #f9fafb; }
+.discount-item--expired { opacity: 0.6; }
+
+.discount-item__main {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.discount-item__info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.discount-item__label {
+  font-weight: 600;
+  color: #292c34;
+  font-size: 15px;
+}
+
+.discount-item__label--expired {
+  text-decoration: line-through;
+  color: #9ca3af;
+}
+
+.discount-item__code {
+  background: #f3f4f6;
+  color: #6b7280;
+  font-size: 12px;
+  font-family: monospace;
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+
+.badge {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.badge--expired { background: #fee2e2; color: #dc2626; }
+.badge--unavailable { background: #fef3c7; color: #d97706; }
+
+.discount-item__amount {
+  font-weight: 700;
+  color: #1bb776;
+  font-size: 15px;
+  white-space: nowrap;
+}
+
+.text-strikethrough { text-decoration: line-through; color: #9ca3af; }
+
+.discount-item__arrow {
+  width: 20px;
+  height: 20px;
+  color: #d1d5db;
+  flex-shrink: 0;
+}
+
+.discount-item__arrow svg { width: 100%; height: 100%; }
+
+@media (max-width: 640px) {
+  .discounts-page { padding: 16px; }
+  .page-header { flex-direction: column; align-items: stretch; }
+  .btn-primary { justify-content: center; }
+}
+</style>

--- a/pages/admin/index.vue
+++ b/pages/admin/index.vue
@@ -457,6 +457,30 @@ export default {
         icon: '<svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" viewBox="0 0 24 24"><g><rect fill="none" height="24" width="24"/></g><g><g><path d="M19,7c0-1.1-0.9-2-2-2h-3v2h3v2.65L13.52,14H10V9H6c-2.21,0-4,1.79-4,4v3h2c0,1.66,1.34,3,3,3s3-1.34,3-3h4.48L19,10.35V7 z M4,14v-1c0-1.1,0.9-2,2-2h2v3H4z M7,17c-0.55,0-1-0.45-1-1h2C8,16.55,7.55,17,7,17z"/><rect height="2" width="5" x="5" y="6"/><path d="M19,13c-1.66,0-3,1.34-3,3s1.34,3,3,3s3-1.34,3-3S20.66,13,19,13z M19,17c-0.55,0-1-0.45-1-1s0.45-1,1-1s1,0.45,1,1 S19.55,17,19,17z"/></g></g></svg>',
       },
       {
+        title: "Kunder",
+        path: "/admin/customers",
+        description: "Søk etter kunder og se statistikk",
+        icon: '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" /></svg>',
+      },
+      {
+        title: "Bonus",
+        path: "/admin/rewards",
+        description: "Administrer bonusprogram og cashback",
+        icon: '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" /></svg>',
+      },
+      {
+        title: "Rabatter",
+        path: "/admin/discounts",
+        description: "Opprett og administrer rabattkoder",
+        icon: '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" /></svg>',
+      },
+      {
+        title: "Betaling",
+        path: "/admin/payment",
+        description: "Betalingsmetoder og Stripe-oppsett",
+        icon: '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" /></svg>',
+      },
+      {
         title: "Okam vekst",
         path: "/admin/poweruser-growth",
         description: "Plattformvekst fra 2020",

--- a/pages/admin/payment.vue
+++ b/pages/admin/payment.vue
@@ -1,0 +1,861 @@
+<template>
+  <AdminPage @login-success="loadPaymentData">
+    <div class="payment-page">
+      <div class="page-header">
+        <h1>Betaling</h1>
+        <p class="page-description">Konfigurer betalingsmetoder og utbetalingsinnstillinger</p>
+      </div>
+
+      <div v-if="isLoading" class="loading-section">
+        <Loading :loading="true" />
+      </div>
+
+      <template v-else-if="selectedStore">
+        <!-- Section: Pay in Store -->
+        <div class="form-section">
+          <div class="section-header">
+            <h2 class="section-title">Betal i butikk</h2>
+            <label class="toggle-switch">
+              <input v-model="paymentForm.payInStoreEnabled" type="checkbox" @change="markDirty" />
+              <span class="toggle-slider" />
+            </label>
+          </div>
+          <p class="section-hint">Kunder kan betale kontant eller med terminal i butikken</p>
+        </div>
+
+        <!-- Section: Giftcard -->
+        <div class="form-section">
+          <div class="section-header">
+            <h2 class="section-title">Gavekort</h2>
+            <label class="toggle-switch">
+              <input v-model="paymentForm.giftcardEnabled" type="checkbox" @change="markDirty" />
+              <span class="toggle-slider" />
+            </label>
+          </div>
+          <p class="section-hint">Aktiver gavekortbetaling for kunder</p>
+
+          <template v-if="paymentForm.giftcardEnabled">
+            <div class="form-field" style="margin-top: 16px;">
+              <label>Kontonummer for utbetaling</label>
+              <div class="input-with-action">
+                <input
+                  v-model="paymentForm.giftcardBankAccountNumber"
+                  type="text"
+                  placeholder="1234.56.78901"
+                  class="text-input"
+                  @input="markDirty"
+                />
+              </div>
+            </div>
+
+            <div v-if="awaitingPayout !== null" class="payout-section">
+              <div class="payout-balance">
+                <span class="payout-balance__label">Tilgjengelig for utbetaling:</span>
+                <span class="payout-balance__amount">{{ formatAmount(awaitingPayout.payoutAmount) }}</span>
+              </div>
+              <div v-if="awaitingPayout.payoutAmount > 0" class="payout-actions">
+                <button
+                  v-if="!awaitingPayout.requested"
+                  class="btn btn-primary btn-sm"
+                  :disabled="isRequestingPayout"
+                  @click="requestGiftcardPayout"
+                >
+                  {{ isRequestingPayout ? 'Ber om utbetaling...' : 'Be om utbetaling' }}
+                </button>
+                <div v-else class="payout-requested">
+                  <span class="badge badge--pending">Utbetaling forespurt</span>
+                  <button class="btn-link" @click="cancelGiftcardPayout">Avbryt</button>
+                </div>
+              </div>
+            </div>
+          </template>
+        </div>
+
+        <!-- Section: Dintero -->
+        <div v-if="paymentConfig.dinteroAvailable" class="form-section">
+          <div class="section-header">
+            <h2 class="section-title">Dintero</h2>
+            <label class="toggle-switch">
+              <input v-model="paymentForm.dinteroEnabled" type="checkbox" @change="markDirty" />
+              <span class="toggle-slider" />
+            </label>
+          </div>
+          <p class="section-hint">Kortbetaling via Dintero</p>
+          <div v-if="paymentConfig.dinteroPrice" class="price-badge">{{ paymentConfig.dinteroPrice }}</div>
+
+          <div v-if="paymentForm.dinteroEnabled" class="subsections">
+            <div v-if="paymentConfig.dinteroBillieAvailable" class="subsection-row">
+              <div class="subsection-info">
+                <span class="subsection-label">Billie (Kjøp nå, betal senere)</span>
+                <span v-if="paymentConfig.dinteroBilliePrice" class="subsection-price">{{ paymentConfig.dinteroBilliePrice }}</span>
+              </div>
+              <label class="toggle-switch toggle-switch--sm">
+                <input v-model="paymentForm.dinteroBillieEnabled" type="checkbox" @change="markDirty" />
+                <span class="toggle-slider" />
+              </label>
+            </div>
+
+            <div v-if="paymentConfig.dinteroKlarnaAvailable" class="subsection-row">
+              <div class="subsection-info">
+                <span class="subsection-label">Klarna</span>
+                <span v-if="paymentConfig.dinteroKlarnaPrice" class="subsection-price">{{ paymentConfig.dinteroKlarnaPrice }}</span>
+              </div>
+              <label class="toggle-switch toggle-switch--sm">
+                <input v-model="paymentForm.dinteroKlarnaEnabled" type="checkbox" @change="markDirty" />
+                <span class="toggle-slider" />
+              </label>
+            </div>
+
+            <div v-if="paymentConfig.dinteroKraviaAvailable" class="subsection-row">
+              <div class="subsection-info">
+                <span class="subsection-label">Kravia</span>
+                <span v-if="paymentConfig.dinteroKraviaPrice" class="subsection-price">{{ paymentConfig.dinteroKraviaPrice }}</span>
+              </div>
+              <label class="toggle-switch toggle-switch--sm">
+                <input v-model="paymentForm.dinteroKraviaEnabled" type="checkbox" @change="markDirty" />
+                <span class="toggle-slider" />
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <!-- Section: Stripe -->
+        <div class="form-section">
+          <div class="section-header">
+            <h2 class="section-title">Kortbetaling (Stripe)</h2>
+            <label class="toggle-switch">
+              <input v-model="paymentForm.stripeEnabled" type="checkbox" @change="onStripeToggle" />
+              <span class="toggle-slider" />
+            </label>
+          </div>
+          <p class="section-hint">Godta kortbetalinger online via Stripe</p>
+
+          <template v-if="paymentForm.stripeEnabled">
+            <!-- No Stripe account -->
+            <div v-if="!paymentForm.stripeBankAccountId" class="stripe-setup">
+              <p class="stripe-setup__text">Du har ikke tilknyttet en Stripe-konto ennå.</p>
+              <button class="btn btn-primary btn-sm" :disabled="isStripeLoading" @click="registerStripe">
+                {{ isStripeLoading ? 'Oppretter...' : 'Registrer Stripe-konto' }}
+              </button>
+            </div>
+
+            <!-- Has Stripe account -->
+            <div v-else-if="stripeAccount" class="stripe-account">
+              <!-- Status badge -->
+              <div class="stripe-status">
+                <div v-if="stripeStatus === 'approved'" class="status-badge status-badge--approved">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                  </svg>
+                  Godkjent
+                </div>
+                <div v-else-if="stripeStatus === 'pending'" class="status-badge status-badge--pending">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  Venter på verifisering
+                </div>
+                <div v-else class="status-badge status-badge--error">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                  </svg>
+                  Mangler dokumentasjon
+                </div>
+              </div>
+
+              <!-- Bank info -->
+              <div v-if="stripeBankInfo" class="stripe-bank-info">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+                </svg>
+                {{ stripeBankInfo.bank_name }} •••• {{ stripeBankInfo.last4 }}
+              </div>
+
+              <!-- Actions -->
+              <div class="stripe-actions">
+                <button class="btn btn-secondary btn-sm" :disabled="isStripeLoading" @click="stripeLogin">
+                  Logg inn i Stripe
+                </button>
+                <button v-if="stripeStatus !== 'approved'" class="btn btn-secondary btn-sm" :disabled="isStripeLoading" @click="stripeOnboard">
+                  Last opp dokumenter
+                </button>
+                <button class="btn btn-danger btn-sm" :disabled="isStripeLoading" @click="confirmDeleteStripe">
+                  Slett konto
+                </button>
+              </div>
+            </div>
+
+            <div v-else class="stripe-setup">
+              <Loading :loading="true" />
+            </div>
+          </template>
+        </div>
+
+        <!-- Section: Report Emails -->
+        <div class="form-section">
+          <h2 class="section-title">Rapportering</h2>
+          <p class="section-hint">Motta betalingsrapporter på e-post</p>
+          <div class="form-field" style="margin-top: 12px;">
+            <label>E-postadresse(r) for rapporter</label>
+            <input
+              v-model="paymentForm.sendInvoiceToEmails"
+              type="text"
+              placeholder="epost@butikk.no, epost2@butikk.no"
+              class="text-input"
+              @input="markDirty"
+            />
+            <span class="field-hint">Separér flere adresser med komma</span>
+          </div>
+        </div>
+
+        <!-- Save Button -->
+        <div class="save-bar">
+          <button class="btn btn-primary" :disabled="isSaving || !isDirty" @click="savePayment">
+            <span v-if="isSaving">Lagrer...</span>
+            <span v-else>Lagre endringer</span>
+          </button>
+          <span v-if="saveStatus === 'saved'" class="save-confirmation">Lagret ✓</span>
+          <span v-else-if="saveStatus === 'error'" class="save-error">Feil ved lagring</span>
+        </div>
+      </template>
+
+      <div v-else class="empty-state">
+        <h3>Velg en butikk</h3>
+        <p>Velg en butikk for å konfigurere betalingsinnstillinger.</p>
+      </div>
+
+      <!-- Toast -->
+      <transition name="toast">
+        <div v-if="toast.show" class="toast" :class="`toast--${toast.type}`">
+          {{ toast.message }}
+        </div>
+      </transition>
+    </div>
+  </AdminPage>
+</template>
+
+<script>
+import AdminPage from '~/components/organisms/AdminPage.vue'
+import Loading from '~/components/atoms/Loading.vue'
+
+export default {
+  name: 'Payment',
+  components: { AdminPage, Loading },
+  data() {
+    return {
+      isLoading: false,
+      isSaving: false,
+      isDirty: false,
+      saveStatus: null,
+      isRequestingPayout: false,
+      isStripeLoading: false,
+      paymentForm: {
+        payInStoreEnabled: false,
+        giftcardEnabled: false,
+        giftcardBankAccountNumber: '',
+        dinteroEnabled: false,
+        dinteroBillieEnabled: false,
+        dinteroKlarnaEnabled: false,
+        dinteroKraviaEnabled: false,
+        stripeEnabled: false,
+        stripeBankAccountId: null,
+        sendInvoiceToEmails: '',
+      },
+      paymentConfig: {
+        dinteroAvailable: false,
+        dinteroPrice: null,
+        dinteroBillieAvailable: false,
+        dinteroBilliePrice: null,
+        dinteroKlarnaAvailable: false,
+        dinteroKlarnaPrice: null,
+        dinteroKraviaAvailable: false,
+        dinteroKraviaPrice: null,
+      },
+      awaitingPayout: null,
+      stripeAccount: null,
+      toast: { show: false, message: '', type: 'success' },
+    }
+  },
+  computed: {
+    selectedStore() {
+      return this.$store.state.selectedAdminStore
+    },
+    stripeStatus() {
+      if (!this.stripeAccount) return null
+      const errs = this.stripeAccount.requirements?.errors || []
+      const pending = this.stripeAccount.requirements?.pending_verification || []
+      if (errs.length > 0) return 'missing_docs'
+      if (pending.length > 0) return 'pending'
+      return 'approved'
+    },
+    stripeBankInfo() {
+      const data = this.stripeAccount?.external_accounts?.data
+      return data && data.length > 0 ? data[0] : null
+    },
+  },
+  watch: {
+    selectedStore: {
+      immediate: true,
+      handler(storeId) {
+        if (storeId) this.loadPaymentData(storeId)
+      },
+    },
+  },
+  methods: {
+    async loadPaymentData(storeId) {
+      this.isLoading = true
+      this.isDirty = false
+      this.saveStatus = null
+      try {
+        const id = storeId || this.selectedStore
+        const [store, payout] = await Promise.all([
+          this._storeService.Get(id),
+          this._payoutService.GetAwaiting(id).catch(() => null),
+        ])
+
+        this._storeService.GetPaymentConfig(id).then(config => {
+          this.paymentConfig = config || {}
+        }).catch(() => {})
+
+        if (store) {
+          this.paymentForm = {
+            payInStoreEnabled: store.payInStoreEnabled || false,
+            giftcardEnabled: store.giftcardEnabled || false,
+            giftcardBankAccountNumber: store.giftcardBankAccountNumber || '',
+            dinteroEnabled: store.dinteroEnabled || false,
+            dinteroBillieEnabled: store.dinteroBillieEnabled || false,
+            dinteroKlarnaEnabled: store.dinteroKlarnaEnabled || false,
+            dinteroKraviaEnabled: store.dinteroKraviaEnabled || false,
+            stripeEnabled: store.stripeEnabled || false,
+            stripeBankAccountId: store.stripeBankAccountId || null,
+            sendInvoiceToEmails: store.sendInvoiceToEmails || '',
+          }
+
+          if (store.stripeBankAccountId) {
+            this.loadStripeAccount(store.stripeBankAccountId)
+          }
+        }
+
+        this.awaitingPayout = payout
+      } catch (e) {
+        this.showToast('Kunne ikke laste betalingsinnstillinger', 'error')
+      } finally {
+        this.isLoading = false
+      }
+    },
+    async loadStripeAccount(accountId) {
+      try {
+        this.stripeAccount = await this._bankAccountService.Get(accountId)
+      } catch (e) {
+        this.stripeAccount = null
+      }
+    },
+    markDirty() {
+      this.isDirty = true
+      this.saveStatus = null
+    },
+    async savePayment() {
+      this.isSaving = true
+      this.saveStatus = null
+      try {
+        await this._storeService.UpdatePayment(this.selectedStore, {
+          payInStoreEnabled: this.paymentForm.payInStoreEnabled,
+          giftcardEnabled: this.paymentForm.giftcardEnabled,
+          giftcardBankAccountNumber: this.paymentForm.giftcardBankAccountNumber,
+          dinteroEnabled: this.paymentForm.dinteroEnabled,
+          dinteroBillieEnabled: this.paymentForm.dinteroBillieEnabled,
+          dinteroKlarnaEnabled: this.paymentForm.dinteroKlarnaEnabled,
+          dinteroKraviaEnabled: this.paymentForm.dinteroKraviaEnabled,
+          stripeEnabled: this.paymentForm.stripeEnabled,
+          sendInvoiceToEmails: this.paymentForm.sendInvoiceToEmails,
+        })
+        this.isDirty = false
+        this.saveStatus = 'saved'
+        setTimeout(() => { this.saveStatus = null }, 3000)
+      } catch (e) {
+        this.saveStatus = 'error'
+        this.showToast('Kunne ikke lagre endringer', 'error')
+      } finally {
+        this.isSaving = false
+      }
+    },
+    async requestGiftcardPayout() {
+      this.isRequestingPayout = true
+      try {
+        await this._payoutService.RequestPayout(this.selectedStore)
+        this.awaitingPayout = { ...this.awaitingPayout, requested: true }
+        this.showToast('Utbetalingsforespørsel sendt', 'success')
+      } catch (e) {
+        this.showToast('Kunne ikke be om utbetaling', 'error')
+      } finally {
+        this.isRequestingPayout = false
+      }
+    },
+    async cancelGiftcardPayout() {
+      try {
+        await this._payoutService.CancelRequestPayout(this.selectedStore)
+        this.awaitingPayout = { ...this.awaitingPayout, requested: false }
+        this.showToast('Utbetalingsforespørsel avbrutt', 'success')
+      } catch (e) {
+        this.showToast('Kunne ikke avbryte forespørsel', 'error')
+      }
+    },
+    onStripeToggle() {
+      this.markDirty()
+    },
+    async registerStripe() {
+      this.isStripeLoading = true
+      try {
+        const account = await this._bankAccountService.Create(this.selectedStore)
+        this.paymentForm.stripeBankAccountId = account.id
+        this.stripeAccount = account
+
+        const onboardData = await this._bankAccountService.Onboard(account.id)
+        if (onboardData?.url) {
+          window.open(onboardData.url, '_blank')
+        }
+        this.markDirty()
+      } catch (e) {
+        this.showToast('Kunne ikke opprette Stripe-konto', 'error')
+      } finally {
+        this.isStripeLoading = false
+      }
+    },
+    async stripeOnboard() {
+      this.isStripeLoading = true
+      try {
+        const data = await this._bankAccountService.Onboard(this.paymentForm.stripeBankAccountId)
+        if (data?.url) window.open(data.url, '_blank')
+      } catch (e) {
+        this.showToast('Kunne ikke åpne Stripe', 'error')
+      } finally {
+        this.isStripeLoading = false
+      }
+    },
+    async stripeLogin() {
+      this.isStripeLoading = true
+      try {
+        const data = await this._bankAccountService.Login(this.paymentForm.stripeBankAccountId)
+        if (data?.url) window.open(data.url, '_blank')
+      } catch (e) {
+        this.showToast('Kunne ikke logge inn i Stripe', 'error')
+      } finally {
+        this.isStripeLoading = false
+      }
+    },
+    async confirmDeleteStripe() {
+      if (!confirm('Er du sikker på at du vil slette Stripe-kontoen? Dette kan ikke angres.')) return
+      this.isStripeLoading = true
+      try {
+        await this._bankAccountService.Delete(this.paymentForm.stripeBankAccountId)
+        this.paymentForm.stripeBankAccountId = null
+        this.paymentForm.stripeEnabled = false
+        this.stripeAccount = null
+        this.markDirty()
+        this.showToast('Stripe-konto slettet', 'success')
+      } catch (e) {
+        this.showToast('Kunne ikke slette Stripe-konto', 'error')
+      } finally {
+        this.isStripeLoading = false
+      }
+    },
+    formatAmount(amount) {
+      if (amount == null) return '0 kr'
+      return `${(amount / 100).toLocaleString('nb-NO', { minimumFractionDigits: 2 })} kr`
+    },
+    showToast(message, type = 'success') {
+      this.toast = { show: true, message, type }
+      setTimeout(() => { this.toast.show = false }, 3000)
+    },
+  },
+}
+</script>
+
+<style scoped>
+.payment-page {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.page-header {
+  margin-bottom: 32px;
+}
+
+.page-header h1 {
+  font-size: 28px;
+  font-weight: 700;
+  color: #292c34;
+  margin: 0 0 4px;
+}
+
+.page-description {
+  color: #6b7280;
+  margin: 0;
+  font-size: 14px;
+}
+
+.loading-section {
+  display: flex;
+  justify-content: center;
+  padding: 60px 0;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 60px 24px;
+  color: #6b7280;
+}
+
+.empty-state h3 {
+  font-size: 18px;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 8px;
+}
+
+.form-section {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  padding: 24px;
+  margin-bottom: 20px;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 8px;
+}
+
+.section-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #292c34;
+  margin: 0;
+}
+
+.section-hint {
+  font-size: 13px;
+  color: #9ca3af;
+  margin: 0 0 0;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.form-field label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.text-input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 14px;
+  color: #292c34;
+  background: #fafafa;
+  box-sizing: border-box;
+  transition: border-color 0.2s;
+}
+
+.text-input:focus {
+  outline: none;
+  border-color: #1bb776;
+  background: white;
+}
+
+.field-hint {
+  font-size: 12px;
+  color: #9ca3af;
+}
+
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.toggle-switch input { opacity: 0; width: 0; height: 0; }
+
+.toggle-switch--sm {
+  width: 36px;
+  height: 20px;
+}
+
+.toggle-slider {
+  position: absolute;
+  inset: 0;
+  background: #e5e7eb;
+  border-radius: 24px;
+  transition: background 0.2s;
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  left: 3px;
+  top: 3px;
+  background: white;
+  border-radius: 50%;
+  transition: transform 0.2s;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+}
+
+.toggle-switch--sm .toggle-slider::before {
+  width: 14px;
+  height: 14px;
+  left: 3px;
+  top: 3px;
+}
+
+.toggle-switch input:checked + .toggle-slider { background: #1bb776; }
+.toggle-switch input:checked + .toggle-slider::before { transform: translateX(20px); }
+.toggle-switch--sm input:checked + .toggle-slider::before { transform: translateX(16px); }
+
+.price-badge {
+  display: inline-block;
+  background: #f0fdf4;
+  color: #1bb776;
+  border: 1px solid #bbf7d0;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 3px 10px;
+  margin-top: 10px;
+}
+
+.subsections {
+  margin-top: 16px;
+  border-top: 1px solid #f3f4f6;
+  padding-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.subsection-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.subsection-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.subsection-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #374151;
+}
+
+.subsection-price {
+  font-size: 12px;
+  color: #9ca3af;
+}
+
+.payout-section {
+  margin-top: 16px;
+  padding: 16px;
+  background: #f9fafb;
+  border-radius: 8px;
+}
+
+.payout-balance {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.payout-balance__label {
+  font-size: 14px;
+  color: #6b7280;
+}
+
+.payout-balance__amount {
+  font-size: 18px;
+  font-weight: 700;
+  color: #292c34;
+}
+
+.payout-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.payout-requested {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.badge {
+  font-size: 12px;
+  font-weight: 600;
+  padding: 3px 10px;
+  border-radius: 999px;
+}
+
+.badge--pending { background: #fef3c7; color: #d97706; }
+
+.btn-link {
+  background: none;
+  border: none;
+  color: #dc2626;
+  font-size: 13px;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.stripe-setup {
+  margin-top: 16px;
+  padding: 20px;
+  background: #f9fafb;
+  border-radius: 8px;
+  text-align: center;
+}
+
+.stripe-setup__text {
+  font-size: 14px;
+  color: #6b7280;
+  margin: 0 0 12px;
+}
+
+.stripe-account {
+  margin-top: 16px;
+  padding: 16px;
+  background: #f9fafb;
+  border-radius: 8px;
+}
+
+.stripe-status {
+  margin-bottom: 12px;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 6px 12px;
+  border-radius: 8px;
+}
+
+.status-badge svg { width: 16px; height: 16px; }
+
+.status-badge--approved { background: #d1fae5; color: #065f46; }
+.status-badge--pending { background: #fef3c7; color: #d97706; }
+.status-badge--error { background: #fee2e2; color: #dc2626; }
+
+.stripe-bank-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: #374151;
+  margin-bottom: 16px;
+}
+
+.stripe-bank-info svg {
+  width: 18px;
+  height: 18px;
+  color: #9ca3af;
+}
+
+.stripe-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.input-with-action {
+  display: flex;
+  gap: 8px;
+}
+
+.save-bar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 24px 0;
+}
+
+.save-confirmation {
+  font-size: 14px;
+  font-weight: 500;
+  color: #1bb776;
+}
+
+.save-error {
+  font-size: 14px;
+  font-weight: 500;
+  color: #dc2626;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: opacity 0.2s;
+}
+
+.btn:hover { opacity: 0.85; }
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.btn-sm { padding: 6px 14px; font-size: 13px; }
+
+.btn-primary { background: linear-gradient(135deg, #1bb776, #159f63); color: white; }
+.btn-secondary { background: #f3f4f6; color: #374151; border: 1px solid #e5e7eb; }
+.btn-danger { background: transparent; color: #dc2626; border: 1px solid #fca5a5; }
+.btn-danger:hover { background: #fee2e2; }
+
+.toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  padding: 14px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  z-index: 1000;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+}
+
+.toast--success { background: #1bb776; color: white; }
+.toast--error { background: #dc2626; color: white; }
+
+.toast-enter-active, .toast-leave-active { transition: all 0.3s; }
+.toast-enter, .toast-leave-to { opacity: 0; transform: translateY(12px); }
+
+@media (max-width: 640px) {
+  .payment-page { padding: 16px; }
+  .stripe-actions { flex-direction: column; }
+}
+</style>

--- a/pages/admin/reward-members.vue
+++ b/pages/admin/reward-members.vue
@@ -1,0 +1,293 @@
+<template>
+  <AdminPage @login-success="loadMembers">
+    <div class="reward-members-page">
+      <div class="page-header">
+        <a href="/admin/rewards" class="back-link">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+          </svg>
+          Bonus
+        </a>
+        <h1>Bonusmedlemmer</h1>
+        <p class="page-description">Listen oppdateres hver natt</p>
+      </div>
+
+      <div v-if="isLoading" class="loading-section">
+        <Loading :loading="true" />
+      </div>
+
+      <template v-else>
+        <div class="search-bar">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="search-icon">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0" />
+          </svg>
+          <input
+            v-model="searchQuery"
+            type="text"
+            placeholder="Søk på telefonnummer..."
+            class="search-input"
+          />
+          <button v-if="searchQuery" class="search-clear" @click="searchQuery = ''">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div v-if="filteredMembers.length === 0" class="empty-state">
+          <div class="empty-state__icon">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+            </svg>
+          </div>
+          <h3>{{ searchQuery ? 'Ingen treff' : 'Ingen medlemmer' }}</h3>
+          <p>{{ searchQuery ? `Ingen medlemmer matcher "${searchQuery}"` : 'Det er ingen bonusmedlemmer ennå.' }}</p>
+        </div>
+
+        <div v-else class="members-list">
+          <div class="members-list__header">
+            <span>Telefon</span>
+            <span>Saldo</span>
+          </div>
+          <div
+            v-for="member in filteredMembers"
+            :key="member.userId || member.userPhoneNumber"
+            class="member-item"
+          >
+            <span class="member-phone">{{ member.userPhoneNumber }}</span>
+            <span class="member-balance">{{ formatBalance(member.balance) }}</span>
+          </div>
+        </div>
+
+        <div v-if="allMembers.length > 0" class="members-count-footer">
+          Viser {{ filteredMembers.length }} av {{ allMembers.length }} medlemmer
+        </div>
+      </template>
+    </div>
+  </AdminPage>
+</template>
+
+<script>
+import AdminPage from '~/components/organisms/AdminPage.vue'
+import Loading from '~/components/atoms/Loading.vue'
+
+export default {
+  name: 'RewardMembers',
+  components: { AdminPage, Loading },
+  data() {
+    return {
+      isLoading: false,
+      allMembers: [],
+      searchQuery: '',
+    }
+  },
+  computed: {
+    selectedStore() {
+      return this.$store.state.selectedAdminStore
+    },
+    filteredMembers() {
+      if (!this.searchQuery) return this.allMembers
+      const q = this.searchQuery.toLowerCase()
+      return this.allMembers.filter(m => (m.userPhoneNumber || '').toLowerCase().includes(q))
+    },
+  },
+  watch: {
+    selectedStore: {
+      immediate: true,
+      handler(storeId) {
+        if (storeId) this.loadMembers(storeId)
+      },
+    },
+  },
+  methods: {
+    async loadMembers(storeId) {
+      this.isLoading = true
+      try {
+        this.allMembers = await this._rewardService.GetMembers(storeId || this.selectedStore) || []
+      } catch (e) {
+        this.allMembers = []
+      } finally {
+        this.isLoading = false
+      }
+    },
+    formatBalance(balance) {
+      if (balance == null) return '0 kr'
+      return `${(balance / 100).toFixed(2).replace('.', ',')} kr`
+    },
+  },
+}
+</script>
+
+<style scoped>
+.reward-members-page {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: #6b7280;
+  font-size: 14px;
+  text-decoration: none;
+  margin-bottom: 8px;
+}
+
+.back-link:hover { color: #292c34; }
+.back-link svg { width: 16px; height: 16px; }
+
+.page-header h1 {
+  font-size: 28px;
+  font-weight: 700;
+  color: #292c34;
+  margin: 0 0 4px;
+}
+
+.page-description {
+  color: #9ca3af;
+  margin: 0 0 24px;
+  font-size: 13px;
+}
+
+.loading-section {
+  display: flex;
+  justify-content: center;
+  padding: 60px 0;
+}
+
+.search-bar {
+  position: relative;
+  margin-bottom: 20px;
+}
+
+.search-icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 18px;
+  color: #9ca3af;
+}
+
+.search-input {
+  width: 100%;
+  padding: 10px 40px 10px 40px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 14px;
+  color: #292c34;
+  background: white;
+  box-sizing: border-box;
+  transition: border-color 0.2s;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #1bb776;
+}
+
+.search-clear {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 20px;
+  height: 20px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #9ca3af;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.search-clear svg { width: 16px; height: 16px; }
+
+.empty-state {
+  text-align: center;
+  padding: 60px 24px;
+}
+
+.empty-state__icon {
+  width: 56px;
+  height: 56px;
+  margin: 0 auto 16px;
+  color: #d1d5db;
+}
+
+.empty-state__icon svg { width: 100%; height: 100%; }
+
+.empty-state h3 {
+  font-size: 18px;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 8px;
+}
+
+.empty-state p {
+  font-size: 14px;
+  color: #9ca3af;
+  margin: 0;
+}
+
+.members-list {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+}
+
+.members-list__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 20px;
+  background: #f9fafb;
+  border-bottom: 1px solid #f3f4f6;
+  font-size: 12px;
+  font-weight: 600;
+  color: #9ca3af;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.member-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 20px;
+  border-bottom: 1px solid #f3f4f6;
+  transition: background 0.15s;
+}
+
+.member-item:last-child { border-bottom: none; }
+.member-item:hover { background: #f9fafb; }
+
+.member-phone {
+  font-size: 14px;
+  color: #292c34;
+  font-weight: 500;
+}
+
+.member-balance {
+  font-size: 14px;
+  font-weight: 700;
+  color: #1bb776;
+}
+
+.members-count-footer {
+  text-align: center;
+  font-size: 13px;
+  color: #9ca3af;
+  padding: 16px;
+}
+
+@media (max-width: 640px) {
+  .reward-members-page { padding: 16px; }
+}
+</style>

--- a/pages/admin/rewards.vue
+++ b/pages/admin/rewards.vue
@@ -1,0 +1,816 @@
+<template>
+  <AdminPage @login-success="loadRewardProgram">
+    <div class="rewards-page">
+      <div class="page-header">
+        <h1>Bonus</h1>
+        <p class="page-description">Administrer bonusprogram og cashback for dine kunder</p>
+      </div>
+
+      <div v-if="isLoading" class="loading-section">
+        <Loading :loading="true" />
+      </div>
+
+      <div v-else-if="!selectedStore" class="empty-state">
+        <h3>Velg en butikk</h3>
+        <p>Velg en butikk for å se bonusprogrammet.</p>
+      </div>
+
+      <!-- No reward program -->
+      <template v-else-if="!hasRewardProgram">
+        <div class="info-card">
+          <div class="info-card__icon">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+            </svg>
+          </div>
+          <div>
+            <h3>Ingen bonusprogram</h3>
+            <p>Opprett et nytt bonusprogram eller koble butikken til et eksisterende.</p>
+          </div>
+        </div>
+
+        <div v-if="otherRewardPrograms.length > 0" class="form-section">
+          <h2 class="section-title">Eksisterende programmer</h2>
+          <div
+            v-for="program in otherRewardPrograms"
+            :key="program.rewardProgramId"
+            class="program-row"
+          >
+            <div class="program-row__info">
+              <span class="program-row__name">{{ program.name || 'Bonusprogram' }}</span>
+              <span class="program-row__stores">{{ program.storeCount || 0 }} butikk(er)</span>
+            </div>
+            <button class="btn btn-secondary btn-sm" :disabled="isInitializing" @click="linkWithExisting(program)">
+              Koble til
+            </button>
+          </div>
+        </div>
+
+        <button class="btn btn-primary" :disabled="isInitializing" @click="initRewardProgram">
+          <span v-if="isInitializing">Oppretter...</span>
+          <span v-else>Opprett nytt bonusprogram</span>
+        </button>
+      </template>
+
+      <!-- Has reward program -->
+      <template v-else>
+        <!-- Enable/Disable -->
+        <div class="form-section">
+          <div class="toggle-row">
+            <div class="toggle-row__info">
+              <span class="toggle-row__label">Aktiver cashback</span>
+              <span class="toggle-row__hint">Kunder tjener cashback på kjøp</span>
+            </div>
+            <label class="toggle-switch">
+              <input v-model="cashbackEnabled" type="checkbox" @change="onSettingChange" />
+              <span class="toggle-slider" />
+            </label>
+          </div>
+        </div>
+
+        <!-- Program Name -->
+        <div class="form-section">
+          <h2 class="section-title">Programnavn</h2>
+          <div class="form-field">
+            <input
+              v-model="rewardProgramName"
+              type="text"
+              placeholder="F.eks. Lojalitetsprogram"
+              class="text-input"
+              @input="onSettingChange"
+            />
+          </div>
+        </div>
+
+        <!-- Cashback Tiers -->
+        <div class="form-section">
+          <h2 class="section-title">Cashback-nivåer</h2>
+
+          <!-- Base percentage -->
+          <div class="tier-base">
+            <label class="tier-base__label">Grunnprosent (0 kr og oppover)</label>
+            <div class="tier-base__input">
+              <input
+                v-model="baseCashbackPercent"
+                type="number"
+                min="0"
+                max="100"
+                placeholder="0"
+                class="text-input text-input--small"
+                @input="onSettingChange"
+              />
+              <span class="input-suffix">%</span>
+            </div>
+          </div>
+
+          <!-- Additional tiers -->
+          <div v-if="additionalTiers.length > 0" class="tiers-list">
+            <div
+              v-for="(tier, index) in additionalTiers"
+              :key="index"
+              class="tier-item"
+            >
+              <div v-if="editingTierIndex === index" class="tier-edit-form">
+                <div class="tier-edit-inputs">
+                  <div class="form-field">
+                    <label>Fra (kr)</label>
+                    <input v-model="editingTier.fromAmount" type="number" min="1" class="text-input text-input--small" />
+                  </div>
+                  <div class="form-field">
+                    <label>Prosent (%)</label>
+                    <input v-model="editingTier.percent" type="number" min="0" max="100" class="text-input text-input--small" />
+                  </div>
+                </div>
+                <div class="tier-edit-actions">
+                  <button class="btn btn-primary btn-sm" @click="saveTierEdit">Lagre</button>
+                  <button class="btn btn-ghost btn-sm" @click="editingTierIndex = -1">Avbryt</button>
+                </div>
+              </div>
+              <div v-else class="tier-display">
+                <span class="tier-display__text">Fra {{ tier.fromAmount }} kr: {{ tier.percent }}%</span>
+                <div class="tier-display__actions">
+                  <button class="btn-icon-only" title="Rediger" @click="startEditTier(index, tier)">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                    </svg>
+                  </button>
+                  <button class="btn-icon-only btn-icon-only--danger" title="Slett" @click="deleteTier(index)">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Add tier form -->
+          <div v-if="showAddTierForm" class="tier-add-form">
+            <div class="tier-edit-inputs">
+              <div class="form-field">
+                <label>Fra (kr)</label>
+                <input v-model="newTier.fromAmount" type="number" min="1" placeholder="500" class="text-input text-input--small" />
+              </div>
+              <div class="form-field">
+                <label>Prosent (%)</label>
+                <input v-model="newTier.percent" type="number" min="0" max="100" placeholder="5" class="text-input text-input--small" />
+              </div>
+            </div>
+            <div class="tier-edit-actions">
+              <button class="btn btn-primary btn-sm" @click="addTier">Legg til</button>
+              <button class="btn btn-ghost btn-sm" @click="showAddTierForm = false">Avbryt</button>
+            </div>
+          </div>
+
+          <button v-if="!showAddTierForm" class="btn btn-secondary btn-sm" style="margin-top: 12px;" @click="openAddTierForm">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="btn-icon">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+            </svg>
+            Legg til nivå
+          </button>
+        </div>
+
+        <!-- Members -->
+        <div class="form-section">
+          <h2 class="section-title">Medlemmer</h2>
+          <div class="members-row">
+            <div class="members-count">
+              <span class="members-count__number">{{ rewardMembershipCount }}</span>
+              <span class="members-count__label">aktive medlemmer</span>
+            </div>
+            <a href="/admin/reward-members" class="btn btn-secondary btn-sm">Se alle</a>
+          </div>
+        </div>
+
+        <!-- Associated Stores -->
+        <div class="form-section">
+          <h2 class="section-title">Tilknyttede butikker</h2>
+          <div class="stores-list">
+            <div
+              v-for="store in rewardStores"
+              :key="store.storeId"
+              class="store-item"
+              :class="{ 'store-item--current': store.storeId === selectedStore }"
+            >
+              <span class="store-item__name">{{ store.storeName }}</span>
+              <span v-if="store.storeId === selectedStore" class="badge badge--current">Denne butikken</span>
+            </div>
+          </div>
+          <button
+            v-if="rewardStores.length > 1"
+            class="btn btn-danger btn-sm"
+            style="margin-top: 16px;"
+            @click="removeStore"
+          >
+            Fjern denne butikken fra programmet
+          </button>
+        </div>
+
+        <!-- Save notification -->
+        <div v-if="saveStatus" class="save-status" :class="`save-status--${saveStatus}`">
+          <span v-if="saveStatus === 'saving'">Lagrer...</span>
+          <span v-else-if="saveStatus === 'saved'">Lagret ✓</span>
+          <span v-else-if="saveStatus === 'error'">Feil ved lagring</span>
+        </div>
+      </template>
+
+      <!-- Toast -->
+      <transition name="toast">
+        <div v-if="toast.show" class="toast" :class="`toast--${toast.type}`">
+          {{ toast.message }}
+        </div>
+      </transition>
+    </div>
+  </AdminPage>
+</template>
+
+<script>
+import AdminPage from '~/components/organisms/AdminPage.vue'
+import Loading from '~/components/atoms/Loading.vue'
+import { debounce } from '~/core/helpers/ts-debounce'
+
+export default {
+  name: 'Rewards',
+  components: { AdminPage, Loading },
+  data() {
+    return {
+      isLoading: false,
+      isInitializing: false,
+      hasRewardProgram: false,
+      cashbackEnabled: false,
+      rewardProgramName: '',
+      baseCashbackPercent: 0,
+      additionalTiers: [],
+      rewardMembershipCount: 0,
+      rewardStores: [],
+      otherRewardPrograms: [],
+      rewardProgramId: null,
+      showAddTierForm: false,
+      newTier: { fromAmount: 0, percent: 0 },
+      editingTierIndex: -1,
+      editingTier: { fromAmount: 0, percent: 0 },
+      saveStatus: null,
+      toast: { show: false, message: '', type: 'success' },
+      debouncedSave: null,
+    }
+  },
+  computed: {
+    selectedStore() {
+      return this.$store.state.selectedAdminStore
+    },
+  },
+  watch: {
+    selectedStore: {
+      immediate: true,
+      handler(storeId) {
+        if (storeId) this.loadRewardProgram(storeId)
+      },
+    },
+  },
+  created() {
+    this.debouncedSave = debounce(this.saveRewardProgram, 2000)
+  },
+  methods: {
+    async loadRewardProgram(storeId) {
+      this.isLoading = true
+      this.hasRewardProgram = false
+      try {
+        const result = await this._rewardService.Get(storeId || this.selectedStore)
+        if (!result || !result.rewardProgram) {
+          this.hasRewardProgram = false
+          this.otherRewardPrograms = result?.otherRewardPrograms || []
+          return
+        }
+
+        this.hasRewardProgram = true
+        this.rewardProgramId = result.rewardProgram.id
+        this.cashbackEnabled = result.rewardProgram.cashbackEnabled || false
+        this.rewardProgramName = result.rewardProgram.name || ''
+        this.rewardMembershipCount = result.rewardProgram.membershipCount || 0
+        this.rewardStores = result.rewardProgram.stores || []
+
+        const ranges = result.rewardProgram.cashbackRanges || []
+        const baseRange = ranges.find(r => r.fromAmount === 0)
+        this.baseCashbackPercent = baseRange ? baseRange.percent : 0
+        this.additionalTiers = ranges.filter(r => r.fromAmount > 0).sort((a, b) => a.fromAmount - b.fromAmount)
+      } catch (e) {
+        this.hasRewardProgram = false
+      } finally {
+        this.isLoading = false
+      }
+    },
+    async initRewardProgram() {
+      this.isInitializing = true
+      try {
+        await this._rewardService.Init(this.selectedStore)
+        await this.loadRewardProgram(this.selectedStore)
+      } catch (e) {
+        this.showToast('Kunne ikke opprette bonusprogram', 'error')
+      } finally {
+        this.isInitializing = false
+      }
+    },
+    async linkWithExisting(program) {
+      this.isInitializing = true
+      try {
+        await this._rewardService.Link(this.selectedStore, program.rewardProgramId)
+        await this.loadRewardProgram(this.selectedStore)
+      } catch (e) {
+        this.showToast('Kunne ikke koble til program', 'error')
+      } finally {
+        this.isInitializing = false
+      }
+    },
+    async removeStore() {
+      if (!confirm('Er du sikker på at du vil fjerne denne butikken fra bonusprogrammet?')) return
+      try {
+        await this._rewardService.Remove(this.selectedStore)
+        await this.loadRewardProgram(this.selectedStore)
+      } catch (e) {
+        this.showToast('Kunne ikke fjerne butikk', 'error')
+      }
+    },
+    onSettingChange() {
+      this.saveStatus = 'saving'
+      this.debouncedSave()
+    },
+    async saveRewardProgram() {
+      try {
+        const allRanges = [
+          { fromAmount: 0, percent: Number(this.baseCashbackPercent) },
+          ...this.additionalTiers.map(t => ({ fromAmount: Number(t.fromAmount), percent: Number(t.percent) })),
+        ]
+        await this._rewardService.Update(this.selectedStore, {
+          name: this.rewardProgramName,
+          cashbackEnabled: this.cashbackEnabled,
+          cashbackRanges: allRanges,
+        })
+        this.saveStatus = 'saved'
+        setTimeout(() => { this.saveStatus = null }, 3000)
+      } catch (e) {
+        this.saveStatus = 'error'
+      }
+    },
+    openAddTierForm() {
+      this.newTier = { fromAmount: 0, percent: 0 }
+      this.showAddTierForm = true
+    },
+    addTier() {
+      if (!this.newTier.fromAmount || Number(this.newTier.fromAmount) <= 0) {
+        this.showToast('Fra-beløp må være større enn 0', 'error')
+        return
+      }
+      this.additionalTiers.push({ fromAmount: Number(this.newTier.fromAmount), percent: Number(this.newTier.percent) })
+      this.additionalTiers.sort((a, b) => a.fromAmount - b.fromAmount)
+      this.showAddTierForm = false
+      this.onSettingChange()
+    },
+    startEditTier(index, tier) {
+      this.editingTierIndex = index
+      this.editingTier = { ...tier }
+    },
+    saveTierEdit() {
+      this.additionalTiers[this.editingTierIndex] = { fromAmount: Number(this.editingTier.fromAmount), percent: Number(this.editingTier.percent) }
+      this.additionalTiers.sort((a, b) => a.fromAmount - b.fromAmount)
+      this.editingTierIndex = -1
+      this.onSettingChange()
+    },
+    deleteTier(index) {
+      this.additionalTiers.splice(index, 1)
+      this.onSettingChange()
+    },
+    showToast(message, type = 'success') {
+      this.toast = { show: true, message, type }
+      setTimeout(() => { this.toast.show = false }, 3000)
+    },
+  },
+}
+</script>
+
+<style scoped>
+.rewards-page {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.page-header {
+  margin-bottom: 32px;
+}
+
+.page-header h1 {
+  font-size: 28px;
+  font-weight: 700;
+  color: #292c34;
+  margin: 0 0 4px;
+}
+
+.page-description {
+  color: #6b7280;
+  margin: 0;
+  font-size: 14px;
+}
+
+.loading-section {
+  display: flex;
+  justify-content: center;
+  padding: 60px 0;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 60px 24px;
+  color: #6b7280;
+}
+
+.empty-state h3 {
+  font-size: 18px;
+  font-weight: 600;
+  color: #374151;
+  margin: 0 0 8px;
+}
+
+.info-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: 12px;
+  padding: 20px;
+  margin-bottom: 24px;
+}
+
+.info-card__icon {
+  width: 40px;
+  height: 40px;
+  color: #1bb776;
+  flex-shrink: 0;
+}
+
+.info-card__icon svg { width: 100%; height: 100%; }
+
+.info-card h3 {
+  font-size: 16px;
+  font-weight: 700;
+  color: #292c34;
+  margin: 0 0 4px;
+}
+
+.info-card p {
+  font-size: 14px;
+  color: #6b7280;
+  margin: 0;
+}
+
+.form-section {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  padding: 24px;
+  margin-bottom: 20px;
+}
+
+.section-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: #292c34;
+  margin: 0 0 16px;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.form-field:last-child { margin-bottom: 0; }
+
+.form-field label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.text-input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 14px;
+  color: #292c34;
+  background: #fafafa;
+  transition: border-color 0.2s;
+  box-sizing: border-box;
+}
+
+.text-input:focus {
+  outline: none;
+  border-color: #1bb776;
+  background: white;
+}
+
+.text-input--small { width: 100px; }
+
+.toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.toggle-row__info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.toggle-row__label {
+  font-size: 15px;
+  font-weight: 600;
+  color: #292c34;
+}
+
+.toggle-row__hint {
+  font-size: 13px;
+  color: #6b7280;
+}
+
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.toggle-switch input { opacity: 0; width: 0; height: 0; }
+
+.toggle-slider {
+  position: absolute;
+  inset: 0;
+  background: #e5e7eb;
+  border-radius: 24px;
+  transition: background 0.2s;
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  left: 3px;
+  top: 3px;
+  background: white;
+  border-radius: 50%;
+  transition: transform 0.2s;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+}
+
+.toggle-switch input:checked + .toggle-slider { background: #1bb776; }
+.toggle-switch input:checked + .toggle-slider::before { transform: translateX(20px); }
+
+.tier-base {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 0;
+  border-bottom: 1px solid #f3f4f6;
+  margin-bottom: 12px;
+}
+
+.tier-base__label {
+  font-size: 14px;
+  color: #374151;
+}
+
+.tier-base__input {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.input-suffix {
+  font-size: 14px;
+  color: #6b7280;
+}
+
+.tiers-list {
+  border: 1px solid #f3f4f6;
+  border-radius: 8px;
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+
+.tier-item {
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.tier-item:last-child { border-bottom: none; }
+
+.tier-display {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+}
+
+.tier-display__text {
+  font-size: 14px;
+  color: #374151;
+}
+
+.tier-display__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.tier-edit-form,
+.tier-add-form {
+  padding: 16px;
+  background: #f9fafb;
+  border-radius: 8px;
+  margin-top: 8px;
+}
+
+.tier-edit-inputs {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.tier-edit-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.members-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.members-count {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.members-count__number {
+  font-size: 32px;
+  font-weight: 700;
+  color: #1bb776;
+}
+
+.members-count__label {
+  font-size: 14px;
+  color: #6b7280;
+}
+
+.stores-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.store-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  background: #f9fafb;
+  border-radius: 8px;
+  border: 1px solid #f3f4f6;
+}
+
+.store-item--current {
+  background: #f0fdf4;
+  border-color: #bbf7d0;
+}
+
+.store-item__name {
+  font-size: 14px;
+  font-weight: 500;
+  color: #374151;
+}
+
+.badge {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+
+.badge--current { background: #d1fae5; color: #065f46; }
+
+.program-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 0;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.program-row:last-child { border-bottom: none; }
+
+.program-row__info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.program-row__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: #292c34;
+}
+
+.program-row__stores {
+  font-size: 12px;
+  color: #9ca3af;
+}
+
+.save-status {
+  text-align: right;
+  font-size: 13px;
+  padding: 8px 0;
+}
+
+.save-status--saving { color: #9ca3af; }
+.save-status--saved { color: #1bb776; }
+.save-status--error { color: #dc2626; }
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: opacity 0.2s;
+  text-decoration: none;
+}
+
+.btn:hover { opacity: 0.85; }
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.btn-sm { padding: 6px 14px; font-size: 13px; }
+
+.btn-primary { background: linear-gradient(135deg, #1bb776, #159f63); color: white; }
+.btn-secondary { background: #f3f4f6; color: #374151; border: 1px solid #e5e7eb; }
+.btn-ghost { background: transparent; color: #6b7280; }
+.btn-danger { background: transparent; color: #dc2626; border: 1px solid #fca5a5; }
+.btn-danger:hover { background: #fee2e2; }
+
+.btn-icon { width: 16px; height: 16px; }
+
+.btn-icon-only {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f3f4f6;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  color: #6b7280;
+  transition: background 0.15s;
+}
+
+.btn-icon-only:hover { background: #e5e7eb; }
+.btn-icon-only svg { width: 16px; height: 16px; }
+
+.btn-icon-only--danger:hover { background: #fee2e2; color: #dc2626; }
+
+.toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  padding: 14px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  z-index: 1000;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+}
+
+.toast--success { background: #1bb776; color: white; }
+.toast--error { background: #dc2626; color: white; }
+
+.toast-enter-active, .toast-leave-active { transition: all 0.3s; }
+.toast-enter, .toast-leave-to { opacity: 0; transform: translateY(12px); }
+
+@media (max-width: 640px) {
+  .rewards-page { padding: 16px; }
+}
+</style>

--- a/plugins/global-mixin.js
+++ b/plugins/global-mixin.js
@@ -28,7 +28,8 @@ import {
   WoltMenuService,
   WoltVenueService,
   RewardService,
-  WrappedService
+  WrappedService,
+  BankAccountService
 } from '~/core/services'
 import { wholeAmount, fractionAmount, priceLabel, formatString } from '~/core/helpers/tools'
 import { formatChf } from '~/utils/price'
@@ -176,7 +177,8 @@ const mixin = {
     _woltMenuService() { return new WoltMenuService(this.$store) },
     _woltVenueService() { return new WoltVenueService(this.$store) },
     _rewardService() { return new RewardService(this.$store) },
-    _wrappedService() { return new WrappedService(this.$store) }
+    _wrappedService() { return new WrappedService(this.$store) },
+    _bankAccountService() { return new BankAccountService(this.$store) }
 
   }
 }


### PR DESCRIPTION
Migrates four pages from the native admin app (okam-as/adminapp) to the
web admin, following established Nuxt.js/Vue 2 patterns in the codebase.

New pages:
- /admin/customers: Customer search (debounced, min 3 chars), statistics
  dashboard with period selector and Chart.js pie chart for platform
  distribution, customer detail modal with reward point sending
- /admin/rewards: Cashback program management with enable/disable toggle,
  tiered cashback ranges (add/edit/delete), member count and store list
- /admin/reward-members: Filterable list of bonus members with balances
- /admin/discounts: Discount list with expiry status
- /admin/discount: Full discount editor (amount/type, applicability,
  optional code, conditions, time window) reusing ProductSelectorModal
- /admin/payment: Payment method configuration including pay-in-store,
  giftcard with payout flow, Dintero sub-options, Stripe account
  onboarding/status, and report email settings

Also adds BankAccountService to global-mixin.js, nav items to
AdminPageHeader.vue, and dashboard cards to the admin index page.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YPS2VFonkRetbg8mnLHf9K