### PR TITLE
Migrate to unified stateless core (service adapter)

### DIFF
--- a/env.ts
+++ b/env.ts
@@ -1,0 +1,22 @@
+// Env accessor for the unified core (core/helpers/configuration.ts imports
+// `getEnv from '../../env'`). The keys are provided via nuxt.config.js `env`,
+// which Nuxt 2's webpack DefinePlugin inlines ONLY for static `process.env.KEY`
+// references — so they must be listed statically here (a dynamic
+// `process.env[name]` would NOT be inlined and would be undefined in the browser).
+const values: { [key: string]: any } = {
+  API_BASE_URL: process.env.API_BASE_URL,
+  VERSION: process.env.VERSION,
+  IS_NATIVESCRIPT: process.env.IS_NATIVESCRIPT,
+  IS_PRODUCTION: process.env.IS_PRODUCTION,
+  STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY,
+  PLATFORM_FILE_SUFFIX: process.env.PLATFORM_FILE_SUFFIX,
+  SELECTED_THEME: process.env.SELECTED_THEME,
+  NOTIFICATION_HUB: process.env.NOTIFICATION_HUB,
+  VIPPS_IOS_PATH: process.env.VIPPS_IOS_PATH,
+  VIPPS_ANDROID_PATH: process.env.VIPPS_ANDROID_PATH
+}
+
+export default (name: string): string => {
+  const value = values[name]
+  return value === undefined || value === null ? '' : String(value)
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -168,6 +168,7 @@ export default {
 
   // Plugins to run before rendering page (https://go.nuxtjs.dev/config-plugins)
   plugins: [
+    { src: '~/plugins/platform-init', ssr: false },
     { src: '~/plugins/global-mixin', ssr: false },
     '~/plugins/market-mixin',
     '~/plugins/i18n',

--- a/platform/http-module.ts
+++ b/platform/http-module.ts
@@ -1,0 +1,11 @@
+import axios from "axios";
+import { IHttpModule } from "~/core/interfaces";
+
+// Web platform HTTP adapter (axios). Registered into core via setPlatform() at startup.
+export class HttpModule implements IHttpModule {
+  httpClient: any;
+
+  constructor() {
+    this.httpClient = axios;
+  }
+}

--- a/platform/persistence-module.ts
+++ b/platform/persistence-module.ts
@@ -1,0 +1,39 @@
+import { IPersistenceModule } from "~/core/interfaces";
+
+// Web platform persistence adapter (localStorage). Registered into core via setPlatform().
+export class PersistenceModule implements IPersistenceModule {
+  exists: any;
+  get: any;
+  set: any;
+  delete: any;
+
+  constructor() {
+    const hasLocalStorage = () => {
+      try {
+        window.localStorage.setItem("localStorageTest", "1");
+        window.localStorage.removeItem("localStorageTest");
+        return true;
+      } catch (e) {
+        return false;
+      }
+    };
+
+    this.exists = (key) => !!this.get(key);
+    this.get = (key) => {
+      if (!hasLocalStorage()) return false;
+      return window.localStorage.getItem(key) || "";
+    };
+    this.set = (key, value) => {
+      if (!hasLocalStorage()) return;
+      let item = value;
+      if (typeof value === "object") {
+        item = JSON.stringify(value);
+      }
+      window.localStorage.setItem(key, item);
+    };
+    this.delete = (key) => {
+      if (!hasLocalStorage()) return;
+      window.localStorage.removeItem(key);
+    };
+  }
+}

--- a/plugins/admin-core-services.js
+++ b/plugins/admin-core-services.js
@@ -1,0 +1,83 @@
+// Admin-only adapters over the unified, stateless core services.
+//
+// The unified core services are stateless API clients constructed from an
+// ICoreInitializer. Unlike the old v3 services they REJECT on auth failure and no
+// longer mutate Vuex internally. These thin subclasses restore the exact v3 contract
+// the admin call-sites depend on — in ONE documented place — by overriding only the
+// methods whose semantics changed and inheriting everything else. No monkey-patching,
+// no per-access method re-binding, no name-drift for un-overridden methods.
+
+import { UserService, CartService } from '~/core/services'
+
+// Only a genuine HTTP 401 (expired/invalid token) should end the session. A transient
+// failure (network blip, 5xx, timeout) or a momentary missing token must NOT log the
+// user out — a catch-all ClearState caused spurious logouts while navigating admin.
+const isUnauthorized = (err) => {
+  const status = err && ((err.response && err.response.status) || err.statusCode || err.status)
+  return status === 401
+}
+
+export class AdminUserService extends UserService {
+  constructor (store, coreInitializer) {
+    super(coreInitializer)
+    this._store = store
+  }
+
+  get _token () {
+    return (this._store.state.currentUser && this._store.state.currentUser.token) || ''
+  }
+
+  // boolean; on success preserve the token (the /user payload has none) + SetCurrentUser.
+  Reload () {
+    return super.Reload()
+      .then((user) => {
+        if (!user) return false
+        user.token = this._token // preserve token across reload (v3 parity)
+        this._store.dispatch('SetCurrentUser', user)
+        return true
+      })
+      .catch((err) => { if (isUnauthorized(err)) this._store.dispatch('ClearState'); return false })
+  }
+
+  // boolean; clear only on a genuine 401.
+  Get () {
+    return super.Get()
+      .then((u) => !!u)
+      .catch((err) => { if (isUnauthorized(err)) this._store.dispatch('ClearState'); return false })
+  }
+
+  // boolean; on success dispatch SetCurrentUser.
+  Login (phoneNumber, token) {
+    return super.Login(phoneNumber, token)
+      .then((user) => { if (user) { this._store.dispatch('SetCurrentUser', user); return true } return false })
+      .catch(() => false)
+  }
+
+  // user|false; on success dispatch SetCurrentUser.
+  LoginAdmin (phoneNumber, token, setCurrentStoreFunction) {
+    return super.LoginAdmin(phoneNumber, token, setCurrentStoreFunction)
+      .then((user) => { if (user) this._store.dispatch('SetCurrentUser', user); return user })
+      .catch(() => false)
+  }
+
+  // route logout through the unified clearState callback.
+  Logout (notificationId) {
+    return super.Logout(notificationId, () => this._store.dispatch('ClearState'))
+  }
+}
+
+export class AdminCartService extends CartService {
+  constructor (store, coreInitializer) {
+    super(coreInitializer)
+    this._store = store
+  }
+
+  // v3 Vuex-mutation helpers removed from the stateless core; re-expose as direct commits.
+  SetLineItem ({ storeId, lineItem }) {
+    this._store.commit('SetLineItem', { storeId, lineItem })
+  }
+
+  RemoveLineItem ({ storeId, lineItem }) {
+    this._store.commit('RemoveLineItem', { storeId, lineItem })
+  }
+}

--- a/plugins/global-mixin.js
+++ b/plugins/global-mixin.js
@@ -1,9 +1,7 @@
 import Vue from 'vue'
 import dayjs from 'dayjs'
 import {
-  CartService,
   ProductService,
-  UserService,
   DiscountService,
   StoreService,
   CategoryService,
@@ -31,6 +29,7 @@ import {
   WrappedService,
   BankAccountService
 } from '~/core/services'
+import { AdminUserService, AdminCartService } from '~/plugins/admin-core-services'
 import { wholeAmount, fractionAmount, priceLabel, formatString, setCurrencyFormat } from '~/core/helpers/tools'
 import { formatChf } from '~/utils/price'
 
@@ -164,52 +163,13 @@ const mixin = {
         cultureCode: this.$store.state.adminLocale || 'no'
       }
     },
-    // UserService adapter. The unified service is stateless and, unlike v3,
-    // REJECTS on a missing token / auth failure (v3 returned a falsy boolean and
-    // mutated Vuex internally). This adapter restores the exact v3 contract so the
-    // app's (often unguarded) `await Reload()` call-sites never crash:
-    //   - Reload: boolean; on success preserve the token + dispatch SetCurrentUser;
-    //     on rejection (no token / 401) dispatch ClearState and return false.
-    //   - Get: boolean; ClearState on failure. Login: boolean. LoginAdmin: user|false.
-    //   - Logout: route through the unified clearState callback.
-    // (Without the reject->false conversion, an unauthenticated /admin visit crashed
-    //  the client mount -> blank page.)
-    _userService() {
-      const svc = new UserService(this._coreInitializer)
-      const store = this.$store
-      const currentToken = () => (store.state.currentUser && store.state.currentUser.token) || ''
-      const _logout = svc.Logout.bind(svc)
-      svc.Logout = (notificationId) => _logout(notificationId, () => store.dispatch('ClearState'))
-      const _reload = svc.Reload.bind(svc)
-      svc.Reload = () => _reload()
-        .then((user) => {
-          if (!user) return false
-          user.token = currentToken() // preserve token across reload (v3 parity)
-          store.dispatch('SetCurrentUser', user)
-          return true
-        })
-        .catch(() => { store.dispatch('ClearState'); return false })
-      const _get = svc.Get.bind(svc)
-      svc.Get = () => _get().then((u) => !!u).catch(() => { store.dispatch('ClearState'); return false })
-      const _login = svc.Login.bind(svc)
-      svc.Login = (phoneNumber, token) => _login(phoneNumber, token)
-        .then((user) => { if (user) { store.dispatch('SetCurrentUser', user); return true } return false })
-        .catch(() => false)
-      const _loginAdmin = svc.LoginAdmin.bind(svc)
-      svc.LoginAdmin = (phoneNumber, token, setCurrentStoreFunction) => _loginAdmin(phoneNumber, token, setCurrentStoreFunction)
-        .then((user) => { if (user) store.dispatch('SetCurrentUser', user); return user })
-        .catch(() => false)
-      return svc
-    },
-    // CartService: SetLineItem/RemoveLineItem were Vuex-mutation helpers in v3
-    // and are gone from the stateless core. Re-expose them as direct commits.
-    _cartService() {
-      const svc = new CartService(this._coreInitializer)
-      const store = this.$store
-      svc.SetLineItem = ({ storeId, lineItem }) => store.commit('SetLineItem', { storeId, lineItem })
-      svc.RemoveLineItem = ({ storeId, lineItem }) => store.commit('RemoveLineItem', { storeId, lineItem })
-      return svc
-    },
+    // UserService / CartService need v3-contract behavior the stateless core dropped
+    // (reject->falsy, auto SetCurrentUser, ClearState only on 401, the removed
+    // SetLineItem/RemoveLineItem Vuex helpers). That logic lives in dedicated adapter
+    // subclasses in ~/plugins/admin-core-services — see that file. Everything else is
+    // a plain stateless client built fresh per access so token/locale read live.
+    _userService() { return new AdminUserService(this.$store, this._coreInitializer) },
+    _cartService() { return new AdminCartService(this.$store, this._coreInitializer) },
     _productService() { return new ProductService(this._coreInitializer) },
     _discountService() { return new DiscountService(this._coreInitializer) },
     _storeService() { return new StoreService(this._coreInitializer) },

--- a/plugins/global-mixin.js
+++ b/plugins/global-mixin.js
@@ -31,8 +31,12 @@ import {
   WrappedService,
   BankAccountService
 } from '~/core/services'
-import { wholeAmount, fractionAmount, priceLabel, formatString } from '~/core/helpers/tools'
+import { wholeAmount, fractionAmount, priceLabel, formatString, setCurrencyFormat } from '~/core/helpers/tools'
 import { formatChf } from '~/utils/price'
+
+// Unified core formats prices via currencyInfo (consumer default "100,–").
+// Admin web keeps the legacy "kr 100" prefix format.
+setCurrencyFormat({ prefix: 'kr ', suffix: '' })
 
 const mixin = {
   data() {
@@ -150,35 +154,69 @@ const mixin = {
       if (this.qsTableName) { qs += 'table=' + encodeURI(this.qsTableName) + '&' }
       return qs ? '?' + qs : ''
     },
-    _userService() { return new UserService(this.$store) },
-    _cartService() { return new CartService(this.$store) },
-    _productService() { return new ProductService(this.$store) },
-    _discountService() { return new DiscountService(this.$store) },
-    _storeService() { return new StoreService(this.$store) },
-    _orderService() { return new OrderService(this.$store) },
-    _statisticsService() { return new StatisticsService(this.$store) },
-    _payoutService() { return new PayoutService(this.$store) },
-    _notificationService() { return new NotificationService(this.$store) },
-    _categoryService() { return new CategoryService(this.$store) },
-    _categoryProductVariantService() { return new CategoryProductVariantService(this.$store) },
-    _productVariantService() { return new ProductVariantService(this.$store) },
-    _deliveryMethodService() { return new DeliveryMethodService(this.$store) },
-    _cultureService() { return new CultureService(this.$store) },
-    _vippsService() { return new VippsService(this.$store) },
-    _paymentService() { return new PaymentService(this.$store) },
-    _dineHomeService() { return new DineHomeService(this.$store) },
-    _aiService() { return new AIService(this.$store) },
-    _offerService() { return new OfferService(this.$store) },
-    _offerProposalService() { return new OfferProposalService(this.$store) },
-    _kamService() { return new KamService(this.$store) },
-    _dinteroService() { return new DinteroService(this.$store) },
-    _kraviaInvoiceService() { return new KraviaInvoiceService(this.$store) },
-    _woltService() { return new WoltService(this.$store) },
-    _woltMenuService() { return new WoltMenuService(this.$store) },
-    _woltVenueService() { return new WoltVenueService(this.$store) },
-    _rewardService() { return new RewardService(this.$store) },
-    _wrappedService() { return new WrappedService(this.$store) },
-    _bankAccountService() { return new BankAccountService(this.$store) }
+    // Unified core services are stateless API clients constructed from an
+    // ICoreInitializer instead of the Vuex store. Built fresh per access so the
+    // bearer token / locale are always read live from the store (reactive).
+    _coreInitializer() {
+      return {
+        bearerToken: (this.$store.state.currentUser && this.$store.state.currentUser.token) || '',
+        clientPlatformName: this.$store.getters.clientPlatformName,
+        cultureCode: this.$store.state.adminLocale || 'no'
+      }
+    },
+    // UserService: stateless in unified core. Re-add the v3 state side-effects
+    // (clear/set currentUser in Vuex) so all call-sites keep working unchanged.
+    _userService() {
+      const svc = new UserService(this._coreInitializer)
+      const store = this.$store
+      const _logout = svc.Logout.bind(svc)
+      svc.Logout = (notificationId) => _logout(notificationId, () => store.dispatch('ClearState'))
+      const _reload = svc.Reload.bind(svc)
+      svc.Reload = async () => { const user = await _reload(); store.dispatch('SetCurrentUser', user); return user }
+      const _loginAdmin = svc.LoginAdmin.bind(svc)
+      svc.LoginAdmin = async (phoneNumber, token, setCurrentStoreFunction) => {
+        const user = await _loginAdmin(phoneNumber, token, setCurrentStoreFunction)
+        if (user) store.dispatch('SetCurrentUser', user)
+        return user
+      }
+      return svc
+    },
+    // CartService: SetLineItem/RemoveLineItem were Vuex-mutation helpers in v3
+    // and are gone from the stateless core. Re-expose them as direct commits.
+    _cartService() {
+      const svc = new CartService(this._coreInitializer)
+      const store = this.$store
+      svc.SetLineItem = ({ storeId, lineItem }) => store.commit('SetLineItem', { storeId, lineItem })
+      svc.RemoveLineItem = ({ storeId, lineItem }) => store.commit('RemoveLineItem', { storeId, lineItem })
+      return svc
+    },
+    _productService() { return new ProductService(this._coreInitializer) },
+    _discountService() { return new DiscountService(this._coreInitializer) },
+    _storeService() { return new StoreService(this._coreInitializer) },
+    _orderService() { return new OrderService(this._coreInitializer) },
+    _statisticsService() { return new StatisticsService(this._coreInitializer) },
+    _payoutService() { return new PayoutService(this._coreInitializer) },
+    _notificationService() { return new NotificationService(this._coreInitializer) },
+    _categoryService() { return new CategoryService(this._coreInitializer) },
+    _categoryProductVariantService() { return new CategoryProductVariantService(this._coreInitializer) },
+    _productVariantService() { return new ProductVariantService(this._coreInitializer) },
+    _deliveryMethodService() { return new DeliveryMethodService(this._coreInitializer) },
+    _cultureService() { return new CultureService(this._coreInitializer) },
+    _vippsService() { return new VippsService(this._coreInitializer) },
+    _paymentService() { return new PaymentService(this._coreInitializer) },
+    _dineHomeService() { return new DineHomeService(this._coreInitializer) },
+    _aiService() { return new AIService(this._coreInitializer) },
+    _offerService() { return new OfferService(this._coreInitializer) },
+    _offerProposalService() { return new OfferProposalService(this._coreInitializer) },
+    _kamService() { return new KamService(this._coreInitializer) },
+    _dinteroService() { return new DinteroService(this._coreInitializer) },
+    _kraviaInvoiceService() { return new KraviaInvoiceService(this._coreInitializer) },
+    _woltService() { return new WoltService(this._coreInitializer) },
+    _woltMenuService() { return new WoltMenuService(this._coreInitializer) },
+    _woltVenueService() { return new WoltVenueService(this._coreInitializer) },
+    _rewardService() { return new RewardService(this._coreInitializer) },
+    _wrappedService() { return new WrappedService(this._coreInitializer) },
+    _bankAccountService() { return new BankAccountService(this._coreInitializer) }
 
   }
 }

--- a/plugins/global-mixin.js
+++ b/plugins/global-mixin.js
@@ -164,21 +164,41 @@ const mixin = {
         cultureCode: this.$store.state.adminLocale || 'no'
       }
     },
-    // UserService: stateless in unified core. Re-add the v3 state side-effects
-    // (clear/set currentUser in Vuex) so all call-sites keep working unchanged.
+    // UserService adapter. The unified service is stateless and, unlike v3,
+    // REJECTS on a missing token / auth failure (v3 returned a falsy boolean and
+    // mutated Vuex internally). This adapter restores the exact v3 contract so the
+    // app's (often unguarded) `await Reload()` call-sites never crash:
+    //   - Reload: boolean; on success preserve the token + dispatch SetCurrentUser;
+    //     on rejection (no token / 401) dispatch ClearState and return false.
+    //   - Get: boolean; ClearState on failure. Login: boolean. LoginAdmin: user|false.
+    //   - Logout: route through the unified clearState callback.
+    // (Without the reject->false conversion, an unauthenticated /admin visit crashed
+    //  the client mount -> blank page.)
     _userService() {
       const svc = new UserService(this._coreInitializer)
       const store = this.$store
+      const currentToken = () => (store.state.currentUser && store.state.currentUser.token) || ''
       const _logout = svc.Logout.bind(svc)
       svc.Logout = (notificationId) => _logout(notificationId, () => store.dispatch('ClearState'))
       const _reload = svc.Reload.bind(svc)
-      svc.Reload = async () => { const user = await _reload(); store.dispatch('SetCurrentUser', user); return user }
+      svc.Reload = () => _reload()
+        .then((user) => {
+          if (!user) return false
+          user.token = currentToken() // preserve token across reload (v3 parity)
+          store.dispatch('SetCurrentUser', user)
+          return true
+        })
+        .catch(() => { store.dispatch('ClearState'); return false })
+      const _get = svc.Get.bind(svc)
+      svc.Get = () => _get().then((u) => !!u).catch(() => { store.dispatch('ClearState'); return false })
+      const _login = svc.Login.bind(svc)
+      svc.Login = (phoneNumber, token) => _login(phoneNumber, token)
+        .then((user) => { if (user) { store.dispatch('SetCurrentUser', user); return true } return false })
+        .catch(() => false)
       const _loginAdmin = svc.LoginAdmin.bind(svc)
-      svc.LoginAdmin = async (phoneNumber, token, setCurrentStoreFunction) => {
-        const user = await _loginAdmin(phoneNumber, token, setCurrentStoreFunction)
-        if (user) store.dispatch('SetCurrentUser', user)
-        return user
-      }
+      svc.LoginAdmin = (phoneNumber, token, setCurrentStoreFunction) => _loginAdmin(phoneNumber, token, setCurrentStoreFunction)
+        .then((user) => { if (user) store.dispatch('SetCurrentUser', user); return user })
+        .catch(() => false)
       return svc
     },
     // CartService: SetLineItem/RemoveLineItem were Vuex-mutation helpers in v3

--- a/plugins/platform-init.js
+++ b/plugins/platform-init.js
@@ -1,0 +1,9 @@
+// Register the web platform implementation into core before services are used.
+// Core is bundler-agnostic and relies on each app registering its own platform via
+// setPlatform(). Listed FIRST in nuxt.config plugins (before store-init / global-mixin)
+// so HttpModule/PersistenceModule are available by the time any core service runs.
+import { HttpModule } from '~/core/platform/http-module.nuxt'
+import { PersistenceModule } from '~/core/platform/persistence-module.nuxt'
+import { setPlatform } from '~/core/platform'
+
+setPlatform(HttpModule, PersistenceModule)

--- a/plugins/platform-init.js
+++ b/plugins/platform-init.js
@@ -2,8 +2,8 @@
 // Core is bundler-agnostic and relies on each app registering its own platform via
 // setPlatform(). Listed FIRST in nuxt.config plugins (before store-init / global-mixin)
 // so HttpModule/PersistenceModule are available by the time any core service runs.
-import { HttpModule } from '~/core/platform/http-module.nuxt'
-import { PersistenceModule } from '~/core/platform/persistence-module.nuxt'
+import { HttpModule } from '~/platform/http-module'
+import { PersistenceModule } from '~/platform/persistence-module'
 import { setPlatform } from '~/core/platform'
 
 setPlatform(HttpModule, PersistenceModule)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,9 @@
   "exclude": [
     "node_modules",
     ".nuxt",
-    "dist"
+    "dist",
+    "core/pinia",
+    "core/platform",
+    "core/translations"
   ]
 }


### PR DESCRIPTION
global-mixin builds an ICoreInitializer and constructs the now-stateless core services from it, via a documented adapter that restores the v3 contract (reject→falsy, SetCurrentUser/ClearState, re-exposed removed methods). Adds env.ts shim + tsconfig excludes; bumps core submodule. Runtime-verified: `/admin` renders login + protected-route redirect, zero console/page errors (Playwright 2/2).

Part of the core consolidation — depends on **https://github.com/Okam-AS/Core/pull/2** (merge the Core PR first so this PR's core submodule pointer resolves on the default branch). The `v3` branch is left untouched.

Verification standard: an actual runtime smoke (Playwright for web, `ns run ios` launch for native), not just build/typecheck — this caught two blank-page bugs that build alone missed.